### PR TITLE
prevent markdown formatting

### DIFF
--- a/Module_1/Agentic_RAG/Agentic_RAG_Notebook.ipynb
+++ b/Module_1/Agentic_RAG/Agentic_RAG_Notebook.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/hamzafarooq/multi-agent-course/blob/main/Module_1/Agentic_RAG/Agentic_RAG_Notebook.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -12,6 +12,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "mJ9XHTOPUCav"
+      },
       "source": [
         "# Deep Dive Agentic Retrieval Augmented Generation\n",
         "\n",
@@ -42,19 +45,16 @@
         "- Scale RAG beyond trivial use cases by integrating multi-step decision logic\n",
         "\n",
         "Importantly, no external agentic frameworks are used—this is a ground-up implementation that demonstrates how to build a lightweight but intelligent agentic system using only a language model, prompt engineering, and retrieval tools."
-      ],
-      "metadata": {
-        "id": "mJ9XHTOPUCav"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Setup and Dependencies"
-      ],
       "metadata": {
         "id": "haelye0PUbdX"
-      }
+      },
+      "source": [
+        "## Setup and Dependencies"
+      ]
     },
     {
       "cell_type": "code",
@@ -73,6 +73,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "J7xIyE7iyI63"
+      },
+      "outputs": [],
       "source": [
         "# Import basic libraries\n",
         "import requests             # Used for making HTTP requests (e.g., calling ARES API for live internet queries)\n",
@@ -99,15 +104,13 @@
         "\n",
         "# Vector database client\n",
         "from qdrant_client import QdrantClient   # Qdrant is used as the vector store to retrieve documents based on similarity\n"
-      ],
-      "metadata": {
-        "id": "J7xIyE7iyI63"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "JE6Bf6r19qhn"
+      },
       "source": [
         "## 1. Defining the Internet Tool\n",
         "\n",
@@ -128,10 +131,7 @@
         "- General knowledge outside internal datasets.\n",
         "\n",
         "Please generate the API key [here](https://api.traversaal.ai)\n"
-      ],
-      "metadata": {
-        "id": "JE6Bf6r19qhn"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -262,6 +262,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Bce4h1DG1mW8"
+      },
+      "outputs": [],
       "source": [
         "# Securely retrieve the OpenAI API key from Colab's user data store\n",
         "# This avoids hardcoding sensitive credentials directly in the notebook\n",
@@ -272,12 +277,7 @@
         "# - Query classification via the router prompt\n",
         "# - Potentially generating responses from retrieved context\n",
         "openaiclient = OpenAI(api_key=openai_api_key)\n"
-      ],
-      "metadata": {
-        "id": "Bce4h1DG1mW8"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
@@ -363,6 +363,7 @@
         "        \"answer\": \"\"\n",
         "    }}\n",
         "\n",
+        "    The response should be in JSON format and not include markdown formatting or code blocks.\n",
         "    Strictly follow this format for every query, and never deviate.\n",
         "    User: {user_query}\n",
         "    \"\"\"\n",
@@ -407,14 +408,14 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "route_query(\"what is the revenue of uber in 2021?\")\n"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "5ilSsVBBv-KT"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "route_query(\"what is the revenue of uber in 2021?\")\n"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -450,6 +451,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "yXAXLB2eCgSn"
+      },
       "source": [
         "#Data Sources:\n",
         "\n",
@@ -458,38 +462,35 @@
         "**OpenAI Docs: Official OpenAI documentation**\n",
         "\n",
         "For lecture demo purposes, the vecitr database has already been created and hosted on Github which we will clone here. In order to create your own embeddings, the notebook and data will be hosted and shared on github"
-      ],
-      "metadata": {
-        "id": "yXAXLB2eCgSn"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "suqlk9P9YJfQ"
+      },
+      "outputs": [],
       "source": [
         "# Clone the project repository that contains prebuilt vector data (e.g., Qdrant collections)\n",
         "# This includes document embeddings and configurations needed for retrieval (10-K, OpenAI docs)\n",
         "\n",
         "!git clone https://github.com/hamzafarooq/multi-agent-course.git\n"
-      ],
-      "metadata": {
-        "id": "suqlk9P9YJfQ"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BB-p1nzYo91-"
+      },
+      "outputs": [],
       "source": [
         "# 🗄️ Initializing Qdrant client with local path to vector database\n",
         "# The path points to prebuilt Qdrant collections (10-K and OpenAI docs) cloned from the repository\n",
         "# This enables fast, local retrieval of relevant document chunks based on semantic similarity\n",
         "client = QdrantClient(path=\"/content/multi-agent-course/Module_1/Agentic_RAG/qdrant_data\")\n"
-      ],
-      "metadata": {
-        "id": "BB-p1nzYo91-"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -549,6 +550,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "nXOx47EKw2ir"
+      },
       "source": [
         "### Step 2: Define the Embedding Function\n",
         "We then define a function get_text_embeddings() which:\n",
@@ -559,13 +563,15 @@
         "- Returns a single vector that represents the full sentence\n",
         "\n",
         "This vector will be used to query Qdrant to find the most relevant document chunks based on similarity."
-      ],
-      "metadata": {
-        "id": "nXOx47EKw2ir"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3r6MeyRz8sv7"
+      },
+      "outputs": [],
       "source": [
         "def rag_formatted_response(user_query: str, context: list):\n",
         "    \"\"\"\n",
@@ -605,15 +611,13 @@
         "\n",
         "    # Return the model's generated answer\n",
         "    return response.choices[0].message.content\n"
-      ],
-      "metadata": {
-        "id": "3r6MeyRz8sv7"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "zdaeGcoCDw5w"
+      },
       "source": [
         "### Step 3: Define the RAG Response Generator\n",
         "After retrieving relevant text chunks from Qdrant, we use the rag_formatted_response() function to generate a final answer. This function:\n",
@@ -626,13 +630,15 @@
         "\n",
         "Together, these two functions lay the foundation for combining retrieval (from vector DB) and generation (from LLM) — the two pillars of a RAG system.\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "zdaeGcoCDw5w"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hp0y2J1AgX2t"
+      },
+      "outputs": [],
       "source": [
         "def retrieve_and_response(user_query: str, action: str):\n",
         "    \"\"\"\n",
@@ -696,15 +702,13 @@
         "    # Catch any unforeseen errors in the overall process\n",
         "    except Exception as err:\n",
         "        return f\"Unexpected error: {err}\"\n"
-      ],
-      "metadata": {
-        "id": "hp0y2J1AgX2t"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "yfYzErTYzhnK"
+      },
       "source": [
         "# 5. Putting It All Together: Running the Agentic RAG\n",
         "In this final step, we combine everything into a single function that controls the entire Agentic RAG workflow. The agentic_rag() function acts as the main orchestrator of the system.\n",
@@ -722,13 +726,15 @@
         "- Displays the final response, neatly formatted in the console.\n",
         "\n",
         "This step brings the agentic loop full circle—from understanding the question, reasoning about where to search, to finally responding with the best possible answer."
-      ],
-      "metadata": {
-        "id": "yfYzErTYzhnK"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ssG-BM9GpT-p"
+      },
+      "outputs": [],
       "source": [
         "# Dictionary that maps the route labels (decided by the router) to their respective functions\n",
         "# Each type of query is handled differently:\n",
@@ -801,90 +807,90 @@
         "        # Catch-all for any unexpected errors in the overall logic\n",
         "        print(f\"{BOLD}{CYAN}🤖 BOT RESPONSE:{RESET}\\n\")\n",
         "        print(f\"Unexpected error occurred: {err}\\n\")\n"
-      ],
-      "metadata": {
-        "id": "ssG-BM9GpT-p"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "\n",
-        "agentic_rag(\"what was uber revenue in 2021?\")"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "0-rTHJpGDTea"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "\n",
+        "agentic_rag(\"what was uber revenue in 2021?\")"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "agentic_rag(\"what was lyft revenue in 2024?\")"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "TncVUsVpu3WC"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "agentic_rag(\"what was lyft revenue in 2024?\")"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "agentic_rag(\"List me down new LLMs\")"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "Mdb97ckP6y2h"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "agentic_rag(\"List me down new LLMs\")"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "agentic_rag(\"how to work with chat completions?\")"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "wpO6W8peh1qO"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "agentic_rag(\"how to work with chat completions?\")"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [],
+      "execution_count": null,
       "metadata": {
         "id": "3PDb2dwa68E7"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "#Assignment: Implement sub-query division"
-      ],
       "metadata": {
         "id": "DKagaRyI4jaK"
-      }
+      },
+      "source": [
+        "#Assignment: Implement sub-query division"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "JZvmbi0QxPzD"
+      },
       "source": [
         "In our current agentic retrieval-augmented generation (RAG) setup, there's a key limitation: when a user submits a query that contains multiple distinct questions phrased as a single input, the system treats it as a single unified search. As a result, the retrieval engine performs only one operation on the vector databases or external tools, which often leads to incomplete or less relevant results.\n",
         "\n",
         "\n",
         "To address this, the assignment introduces a new functionality called subquery division. This involves breaking down complex, compound queries into multiple, focused subqueries. Each subquery is processed independently, allowing the system to retrieve more accurate and context-specific information. By handling these subqueries separately, the agent can generate more complete and relevant responses."
-      ],
-      "metadata": {
-        "id": "JZvmbi0QxPzD"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "DBq_Y-w1B0DF"
+      },
+      "outputs": [],
       "source": [
         "#Reference Code for sub query division (For Guidance Only)\n",
         "\n",
@@ -907,29 +913,24 @@
         "        ]\n",
         "    )\n",
         "  return response.choices[0].message.content\n"
-      ],
-      "metadata": {
-        "id": "DBq_Y-w1B0DF"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "print(sub_queries(\"what is revenue of lyft and what is reveue for uber in 2024\"))"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "ldR3RgLLw3UE"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "print(sub_queries(\"what is revenue of lyft and what is reveue for uber in 2024\"))"
+      ]
     }
   ],
   "metadata": {
     "colab": {
-      "provenance": [],
-      "include_colab_link": true
+      "include_colab_link": true,
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
This adds a line to the prompt to prevent getting responses back in markdown format, which was an issue in the demo.

It looks like the JSON keys were also automatically reordered to be in alphabetical order as part of the auto-formatting process. I think that's a good thing to have in general, but let me know if it's an issue.