### PR TITLE
Add agent runtime and references for ADK to Anthropic SDK porting

### DIFF
--- a/.claude/skills/adk-to-anthropic-sdk/SKILL.md
+++ b/.claude/skills/adk-to-anthropic-sdk/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: adk-to-anthropic-sdk
+description: Convert Google ADK (Agent Development Kit) multi-agent Python projects into equivalent code that runs directly on the Anthropic SDK (the `anthropic` Python package). Use this skill whenever the user points at a folder, repo, or set of Python files built with Google ADK — anything importing `google.adk`, using `Agent`/`LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent`, `Runner`, `FunctionTool`, ADK `tools`, `sub_agents`, or `session`/`Runner` orchestration — and wants it rewritten, ported, migrated, or "translated" to the Anthropic SDK. Trigger this even if the user just says "convert this agent project to use Claude/Anthropic," "port my ADK code," "migrate off Google ADK," or "make this run on the Anthropic API," and even when they don't name ADK explicitly but the code clearly uses it. The skill takes a project folder, produces a working Anthropic-SDK port, and verifies it is import-clean, syntactically valid, and passes a mocked dry run before optionally doing a live API smoke test.
+---
+
+# ADK → Anthropic SDK Converter
+
+Port a Google ADK multi-agent project to run on the raw Anthropic Python SDK, preserving behavior (agent roles, tools, orchestration topology, control flow) while removing the `google.adk` dependency. Then prove the port works.
+
+## Workflow
+
+Follow these phases in order. Don't skip the analysis phase — ADK projects encode their agent graph implicitly, and getting the topology wrong is the most common failure.
+
+### Phase 1 — Inventory the source project
+
+1. Locate the project. The user gives you a folder (often under `/mnt/user-data/uploads`). Copy it to a writable workspace (`/home/claude/port/`) before touching anything — never edit the read-only original.
+2. Map the codebase: list all `.py` files, find every `google.adk` import, and identify entry points (files with `Runner`, `__main__`, or a `root_agent`).
+3. Build an **agent inventory**. For each ADK agent capture: its name, `model`, `instruction`/`description` (becomes the system prompt), `tools`, and `sub_agents`. Record how agents connect — this is the orchestration topology.
+4. Identify the orchestration pattern. ADK ships a few; see `references/adk-patterns.md` for the full mapping. The common ones: a single `LlmAgent` with tools, `SequentialAgent` (pipeline), `ParallelAgent` (fan-out/gather), `LoopAgent` (iterate until a condition), and agent-as-tool / `sub_agents` delegation.
+5. Inventory tools: ADK `FunctionTool`s are plain Python functions plus a schema. They port almost directly to Anthropic tool-use definitions — keep the function bodies, regenerate the schema.
+6. Flag the protocol layer. If the project imports `MCPToolset`/`StdioServerParameters` (tools from an MCP server) or uses A2A (agent cards, `/.well-known/agent.json`, networked agent services), those are **not** plain tools — they need dedicated handling. See `references/mcp-and-a2a.md` and record the transport (local stdio vs. remote HTTP) and your port decision in `INVENTORY.md`.
+
+Write the inventory to `port/INVENTORY.md` so the mapping is explicit and reviewable before you write code.
+
+### Phase 2 — Choose the target shape
+
+Pick the simplest Anthropic-SDK structure that preserves behavior. Don't over-engineer — a three-agent ADK pipeline should not become a framework.
+
+- **Single agent + tools** → one `messages.create` tool-use loop. See `references/sdk-tool-loop.md`.
+- **Sequential / pipeline** → call each agent loop in order, threading output → input. See `references/orchestration.md`.
+- **Parallel fan-out** → run agent loops concurrently (`asyncio.gather` with `AsyncAnthropic`), then merge.
+- **Loop until condition** → wrap an agent loop in a `while` with the ADK exit condition.
+- **Delegation / sub-agents** → expose each sub-agent as a tool the orchestrator can call, or as a direct function call when delegation is static.
+- **MCP tools / A2A services** → port the MCP toolset (native `mcp_servers` connector for remote servers, or a local MCP client bridge for stdio servers) and decide whether A2A boundaries collapse in-process or stay as a thin HTTP layer. See `references/mcp-and-a2a.md`.
+
+Watch for **short-circuit control flow** inside a pipeline — e.g. a guard/judge sub-agent that returns `"BLOCKED"` to stop the chain. Preserve that conditional exactly; a naive output→input thread silently loses it.
+
+Read `references/adk-patterns.md` and the matching orchestration reference before writing code. Reuse the helpers in `assets/agent_runtime.py` rather than reinventing the tool-use loop each time — copy that file into the port and build on it.
+
+### Phase 3 — Translate
+
+1. Copy `assets/agent_runtime.py` into `port/`. It provides a reusable `Agent` class and `run_agent()` tool-use loop on top of the Anthropic SDK so the ported code stays small and consistent.
+2. Recreate each ADK agent as an `Agent` instance (system prompt from `instruction`, tools from the ported functions, model mapped per `references/model-mapping.md`).
+3. Port tools: keep each function body verbatim; generate an Anthropic tool schema from its signature/docstring (the runtime has a helper, or write explicit schemas for clarity).
+4. Reconstruct the orchestration in a top-level entry point that mirrors the original control flow.
+5. Map models: ADK model strings (e.g. Gemini names, or `LiteLlm(...)`) map to current Anthropic model IDs per `references/model-mapping.md`. Default to `claude-sonnet-4-6` unless the source clearly wanted the most capable (`claude-opus-4-8`) or cheapest/fastest (`claude-haiku-4-5-20251001`) tier.
+6. Preserve I/O contracts: same CLI args, same function names for public entry points, same return shapes, so the port is a drop-in where possible.
+7. Write a `requirements.txt` (`anthropic`, plus whatever non-ADK deps the original used) and a short `README_PORT.md` explaining what changed.
+
+Keep the original file structure where reasonable so a reviewer can diff mentally.
+
+### Phase 4 — Verify (this is the "error-free" guarantee)
+
+Verification is layered, cheapest first. Run `scripts/verify_port.py <port-dir>`, which performs:
+
+1. **Syntax check** — `compile()` every `.py` file. Fails loudly with file + line on any `SyntaxError`.
+2. **Import check** — import each module in a subprocess with a **mocked `anthropic` package** injected, so no network or key is needed. Catches missing names, bad signatures, leftover `google.adk` references.
+3. **ADK-residue scan** — grep for any surviving `google.adk` / ADK symbols and fail if found (the whole point is removing that dependency).
+4. **Mocked dry run** — if the project exposes a detected entry point, execute it against a fake Anthropic client that returns canned tool-use and text responses, exercising the orchestration end-to-end without spending tokens.
+
+The script prints a clear PASS/FAIL per stage and a final summary. Iterate: read the failure, fix the port, re-run, until all stages pass. See `references/verification.md` for how the mock works and how to extend the dry run for unusual entry points.
+
+**Live smoke test (optional, only if the user asks and a key is present):** if `ANTHROPIC_API_KEY` is set and the user wants real confirmation, run the entry point once with a tiny input and the cheapest model. Keep it minimal — the goal is "it really talks to the API," not a full eval.
+
+### Phase 5 — Deliver
+
+Present the ported folder, the `INVENTORY.md`, the verification output, and a brief changelog. If `present_files` is available, present the port directory's key files. Tell the user exactly how to run it (`pip install -r requirements.txt`, set `ANTHROPIC_API_KEY`, run the entry point).
+
+## Principles
+
+- **Behavior-preserving, not framework-preserving.** The user wants Claude-powered agents that do the same thing — not a clone of ADK's abstractions on top of Anthropic.
+- **Smallest faithful structure wins.** Prefer plain functions and a thin runtime over a new framework.
+- **Verification is not optional.** A port that imports but was never dry-run is not done. Always run `verify_port.py` and report results.
+- **Never edit the original.** Always work on a copy.
+- **When the ADK topology is ambiguous**, state your interpretation in `INVENTORY.md` and ask the user to confirm rather than guessing silently.
+
+## Reference files
+
+- `references/adk-patterns.md` — ADK agent types & orchestration → Anthropic equivalents (read first).
+- `references/sdk-tool-loop.md` — the canonical Anthropic tool-use loop.
+- `references/orchestration.md` — sequential / parallel / loop / delegation recipes.
+- `references/mcp-and-a2a.md` — porting MCP toolsets (native connector or local client bridge) and A2A services.
+- `references/model-mapping.md` — Gemini/LiteLlm model strings → Anthropic model IDs.
+- `references/verification.md` — how `verify_port.py` works and how to extend it.
+- `assets/agent_runtime.py` — reusable Agent class + tool-use loop to copy into ports.
+- `scripts/verify_port.py` — the layered verifier.

--- a/.claude/skills/adk-to-anthropic-sdk/assets/agent_runtime.py
+++ b/.claude/skills/adk-to-anthropic-sdk/assets/agent_runtime.py
@@ -1,0 +1,182 @@
+"""
+agent_runtime.py — reusable Agent runtime on top of the Anthropic SDK.
+
+Copy this file into a ported project. It provides:
+  - Agent: a configured agent (system prompt, model, tools, handlers)
+  - run_agent / Agent.run: synchronous tool-use loop
+  - Agent.arun: async tool-use loop (for parallel orchestration)
+  - tool_from_function: build an Anthropic tool schema from a Python function
+
+The point is to keep ports small: recreate each ADK agent as an Agent and
+wire orchestration with plain Python, instead of re-implementing the tool
+loop everywhere.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+try:
+    from anthropic import Anthropic, AsyncAnthropic
+except ImportError:  # allows static import-checks without the package installed
+    Anthropic = AsyncAnthropic = None  # type: ignore
+
+_PY_TO_JSON = {
+    str: "string", int: "integer", float: "number",
+    bool: "boolean", list: "array", dict: "object",
+}
+
+
+def tool_from_function(func: Callable) -> dict:
+    """Generate an Anthropic tool schema from a function's signature + docstring.
+
+    For complex types, prefer writing the schema explicitly.
+    """
+    sig = inspect.signature(func)
+    props, required = {}, []
+    for name, param in sig.parameters.items():
+        ann = param.annotation
+        json_type = _PY_TO_JSON.get(ann, "string")
+        props[name] = {"type": json_type}
+        if param.default is inspect.Parameter.empty:
+            required.append(name)
+    doc = (func.__doc__ or func.__name__).strip().split("\n")[0]
+    return {
+        "name": func.__name__,
+        "description": doc,
+        "input_schema": {"type": "object", "properties": props, "required": required},
+    }
+
+
+def _final_text(content) -> str:
+    return "".join(b.text for b in content if getattr(b, "type", None) == "text")
+
+
+class Agent:
+    """A single Claude-powered agent: system prompt + model + tools."""
+
+    def __init__(
+        self,
+        name: str,
+        system: str,
+        model: str = "claude-sonnet-4-6",
+        tools: list[dict] | None = None,
+        handlers: dict[str, Callable] | None = None,
+        max_tokens: int = 4096,
+        max_turns: int = 10,
+        client: Any = None,
+        async_client: Any = None,
+    ):
+        self.name = name
+        self.system = system
+        self.model = model
+        self.tools = tools or []
+        self.handlers = handlers or {}
+        self.max_tokens = max_tokens
+        self.max_turns = max_turns
+        self._client = client
+        self._async_client = async_client
+
+    # ---- tool registration helper ----
+    def add_function_tool(self, func: Callable):
+        self.tools.append(tool_from_function(func))
+        self.handlers[func.__name__] = func
+        return self
+
+    def _get_client(self):
+        if self._client is None:
+            if Anthropic is None:
+                raise RuntimeError("anthropic package not installed")
+            self._client = Anthropic()
+        return self._client
+
+    def _get_async_client(self):
+        if self._async_client is None:
+            if AsyncAnthropic is None:
+                raise RuntimeError("anthropic package not installed")
+            self._async_client = AsyncAnthropic()
+        return self._async_client
+
+    def _dispatch(self, block) -> dict:
+        handler = self.handlers.get(block.name)
+        if handler is None:
+            return {"type": "tool_result", "tool_use_id": block.id,
+                    "content": f"Error: no handler for tool '{block.name}'",
+                    "is_error": True}
+        try:
+            output = handler(**(block.input or {}))
+            return {"type": "tool_result", "tool_use_id": block.id,
+                    "content": str(output)}
+        except Exception as e:  # surface tool errors to the model
+            return {"type": "tool_result", "tool_use_id": block.id,
+                    "content": f"Error: {e}", "is_error": True}
+
+    # ---- synchronous run ----
+    def run(self, user_input: str,
+            extra_tools: list[dict] | None = None,
+            extra_handlers: dict[str, Callable] | None = None) -> str:
+        client = self._get_client()
+        tools = self.tools + (extra_tools or [])
+        handlers = {**self.handlers, **(extra_handlers or {})}
+        messages = [{"role": "user", "content": user_input}]
+        for _ in range(self.max_turns):
+            kwargs = dict(model=self.model, max_tokens=self.max_tokens,
+                          system=self.system, messages=messages)
+            if tools:
+                kwargs["tools"] = tools
+            resp = client.messages.create(**kwargs)
+            messages.append({"role": "assistant", "content": resp.content})
+            if resp.stop_reason != "tool_use":
+                return _final_text(resp.content)
+            results = [self._dispatch(b) for b in resp.content
+                       if getattr(b, "type", None) == "tool_use"]
+            messages.append({"role": "user", "content": results})
+        return _final_text(messages[-1]["content"]) if messages else ""
+
+    # ---- async run (for ParallelAgent ports) ----
+    async def arun(self, user_input: str,
+                   extra_tools: list[dict] | None = None,
+                   extra_handlers: dict[str, Callable] | None = None) -> str:
+        client = self._get_async_client()
+        tools = self.tools + (extra_tools or [])
+        handlers = {**self.handlers, **(extra_handlers or {})}
+        messages = [{"role": "user", "content": user_input}]
+        for _ in range(self.max_turns):
+            kwargs = dict(model=self.model, max_tokens=self.max_tokens,
+                          system=self.system, messages=messages)
+            if tools:
+                kwargs["tools"] = tools
+            resp = await client.messages.create(**kwargs)
+            messages.append({"role": "assistant", "content": resp.content})
+            if resp.stop_reason != "tool_use":
+                return _final_text(resp.content)
+            results = []
+            for b in resp.content:
+                if getattr(b, "type", None) == "tool_use":
+                    h = handlers.get(b.name)
+                    if h is None:
+                        results.append({"type": "tool_result", "tool_use_id": b.id,
+                                        "content": f"Error: no handler for '{b.name}'",
+                                        "is_error": True})
+                        continue
+                    try:
+                        out = h(**(b.input or {}))
+                        if inspect.isawaitable(out):
+                            out = await out
+                        results.append({"type": "tool_result", "tool_use_id": b.id,
+                                        "content": str(out)})
+                    except Exception as e:
+                        results.append({"type": "tool_result", "tool_use_id": b.id,
+                                        "content": f"Error: {e}", "is_error": True})
+            messages.append({"role": "user", "content": results})
+        return _final_text(messages[-1]["content"]) if messages else ""
+
+
+# Convenience functional form mirroring the reference doc.
+def run_agent(system, tools, tool_handlers, user_input,
+              model="claude-sonnet-4-6", max_turns=10, max_tokens=4096):
+    agent = Agent(name="agent", system=system, model=model, tools=tools or [],
+                  handlers=tool_handlers or {}, max_turns=max_turns,
+                  max_tokens=max_tokens)
+    return agent.run(user_input)

--- a/.claude/skills/adk-to-anthropic-sdk/references/adk-patterns.md
+++ b/.claude/skills/adk-to-anthropic-sdk/references/adk-patterns.md
@@ -1,0 +1,95 @@
+# ADK Patterns → Anthropic SDK Equivalents
+
+Google ADK structures an app as a tree of agents. To port it, identify which ADK construct each agent uses, then map to the Anthropic equivalent. Read this before writing code.
+
+## Table of contents
+- Agent types
+- Orchestration agents
+- Tools
+- Sessions & state
+- Runner / entry points
+- Mapping cheat sheet
+
+## Agent types
+
+### `LlmAgent` / `Agent`
+The workhorse: an LLM with an `instruction` (system prompt), a `model`, and optional `tools` and `sub_agents`.
+
+```python
+from google.adk.agents import LlmAgent
+agent = LlmAgent(
+    name="researcher",
+    model="gemini-2.0-flash",
+    instruction="You research topics and summarize findings.",
+    tools=[search_tool],
+)
+```
+
+→ Anthropic equivalent: one `Agent` (from `agent_runtime.py`) whose `system` is the `instruction`, whose `tools` are ported tool schemas, run through `run_agent()` (a `messages.create` tool-use loop). The `model` maps via `model-mapping.md`.
+
+## Orchestration agents
+
+ADK provides workflow agents that contain `sub_agents`. These define control flow, not LLM calls themselves.
+
+### `SequentialAgent`
+Runs sub-agents in order; each sees prior output (often via shared session state keyed by `output_key`).
+→ Call each ported agent loop in sequence, threading the previous result into the next agent's input message. See `orchestration.md` → Sequential.
+
+### `ParallelAgent`
+Runs sub-agents concurrently, results gathered.
+→ `asyncio.gather` over async agent loops using `AsyncAnthropic`, then merge results. See `orchestration.md` → Parallel.
+
+### `LoopAgent`
+Repeats its sub-agent(s) until `max_iterations` or an escalation/exit signal.
+→ A `while` loop around the agent call with the same termination condition (iteration cap and/or a checked exit predicate). See `orchestration.md` → Loop.
+
+### Agent-as-tool / `sub_agents` delegation
+An orchestrator `LlmAgent` lists other agents in `sub_agents` (or wraps them with `AgentTool`) and decides at runtime which to invoke.
+→ Expose each sub-agent as an Anthropic tool whose handler runs that sub-agent's loop and returns its output. The orchestrator's tool-use loop then performs delegation naturally. See `orchestration.md` → Delegation.
+
+## Tools
+
+ADK `FunctionTool` (or a bare function passed to `tools=`) = a Python function whose signature + docstring define the schema. The model calls it; ADK runs it and feeds the result back.
+
+→ Keep the function body unchanged. Produce an Anthropic tool definition:
+```python
+{
+  "name": "fn_name",
+  "description": "<docstring summary>",
+  "input_schema": { "type": "object", "properties": {...}, "required": [...] },
+}
+```
+Map Python types: `str`→`string`, `int`→`integer`, `float`→`number`, `bool`→`boolean`, `list`→`array`, `dict`→`object`. `agent_runtime.py` has `tool_from_function()` to autogenerate this from a signature; prefer explicit schemas when types are complex.
+
+ADK special tools (`google_search`, `built_in_code_execution`, etc.) have no 1:1 Anthropic builtin in the raw SDK — reimplement as a normal tool (e.g. a real search function) or note the gap in `INVENTORY.md`.
+
+**MCP toolsets** (`MCPToolset.from_server`, `StdioServerParameters`) are a different beast — tools
+loaded dynamically from an MCP server, not local functions. Port via the native Anthropic
+`mcp_servers` connector (remote servers) or a local MCP client bridge (stdio servers). See
+`references/mcp-and-a2a.md`. The verifier's residue scan fails if `MCPToolset`/`StdioServerParameters`
+survive in the port.
+
+## Sessions & state
+
+ADK uses `SessionService` + `session.state` (a dict) to pass data between agents, often via `output_key`. The raw Anthropic SDK is stateless per call.
+→ Replace session state with explicit Python variables / a plain dict passed between agent calls. `output_key="foo"` means "store this agent's final text under `foo`" — model it as `state["foo"] = result`.
+
+## Runner / entry points
+
+ADK runs agents via `Runner(agent=..., session_service=...).run(...)` or `runner.run_async(...)`, yielding events.
+→ Replace with a direct call to your top-level orchestration function. Preserve the same inputs (query string, args) and final output. Keep a `if __name__ == "__main__":` CLI if the original had one.
+
+## Mapping cheat sheet
+
+| ADK | Anthropic SDK port |
+|-----|--------------------|
+| `LlmAgent`/`Agent` | `Agent` + `run_agent()` tool-use loop |
+| `instruction` | `system` prompt |
+| `model="gemini-..."` | Anthropic model id (see model-mapping.md) |
+| `FunctionTool` / function | tool schema + unchanged handler |
+| `SequentialAgent` | ordered calls, thread output→input |
+| `ParallelAgent` | `asyncio.gather` over async loops |
+| `LoopAgent` | `while` with iteration cap / exit check |
+| `sub_agents` / `AgentTool` | sub-agent exposed as a tool, or direct call |
+| `session.state` / `output_key` | plain dict / variables |
+| `Runner.run` | top-level orchestration function |

--- a/.claude/skills/adk-to-anthropic-sdk/references/mcp-and-a2a.md
+++ b/.claude/skills/adk-to-anthropic-sdk/references/mcp-and-a2a.md
@@ -1,0 +1,84 @@
+# MCP Toolsets & A2A → Anthropic SDK
+
+ADK projects often pull tools from an **MCP server** and/or expose agents over the **A2A**
+(agent-to-agent) protocol. These are not plain `FunctionTool`s and need their own handling.
+Read this when the source imports `MCPToolset`, `StdioServerParameters`, `mcp_tool`, or any
+A2A server/client (`a2a`, agent cards, `/.well-known/agent.json`, task endpoints).
+
+## MCP toolsets (was `MCPToolset.from_server`)
+
+ADK loads MCP tools dynamically:
+
+```python
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+
+tools, exit_stack = await MCPToolset.from_server(
+    connection_params=StdioServerParameters(command="python", args=["./servers/server_mcp.py"]),
+)
+agent = LlmAgent(model="gemini-2.5-pro", name="sql", instruction="...", tools=tools)
+```
+
+You have **two faithful ports**. Pick by how the MCP server is reached:
+
+### Option A — native Anthropic MCP connector (preferred when the server is remote/HTTP)
+The Anthropic Messages API can talk to MCP servers directly via the `mcp_servers` parameter
+(the MCP connector). The model calls MCP tools without you writing a tool-use dispatch loop
+for them. Use this when the MCP server is reachable over HTTP/SSE.
+
+```python
+resp = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=4096,
+    system=instruction,
+    messages=messages,
+    mcp_servers=[{"type": "url", "url": "https://your-mcp-server/sse", "name": "security-hub"}],
+)
+```
+Confirm the exact `mcp_servers` shape and any required beta header against `claude-api`
+(load that skill) — the connector's request shape and headers change, so don't hardcode from
+memory.
+
+### Option B — local MCP client + tool bridge (when the server is stdio/local)
+The repo's `StdioServerParameters(command="python", args=["./servers/server_mcp.py"])` spawns a
+**local** stdio MCP server — the API connector can't reach a subprocess on your machine. Bridge
+it yourself with the official `mcp` Python package:
+
+1. Start the server as an MCP client session (`mcp.client.stdio.stdio_client`).
+2. `await session.list_tools()` → convert each MCP tool's `inputSchema` into an Anthropic tool
+   schema (the schema is already JSON Schema — usually a direct pass-through to `input_schema`).
+3. In your tool-use loop, dispatch each `tool_use` by calling `await session.call_tool(name, input)`
+   and feed the result back as a `tool_result`.
+
+This keeps the same MCP server the ADK app used; only the *client* changes from ADK to your loop.
+`agent_runtime.py`'s loop already handles dispatch — register MCP-backed handlers that call
+`session.call_tool`.
+
+> Either way: `MCPToolset`/`StdioServerParameters` must be **gone** from the port (the residue
+> scan now fails on them). Record which option you chose, and the server's transport, in
+> `INVENTORY.md`.
+
+## A2A (agent-to-agent protocol)
+
+A2A exposes an agent as a network service (an agent card at `/.well-known/agent.json`, task
+submission/streaming endpoints) so *other* agents call it over HTTP. This is a **transport/
+deployment** concern, not an LLM concern — the Anthropic SDK has no A2A equivalent.
+
+Decide with the user, and write the decision in `INVENTORY.md`:
+
+- **In-process port (default).** If A2A was only used to wire local sub-agents together, drop the
+  protocol entirely and call the ported agents as plain Python (sequential/parallel/delegation
+  recipes in `orchestration.md`). This is almost always what's wanted.
+- **Keep the service boundary.** If agents genuinely run as separate networked services, port each
+  agent's *logic* to the Anthropic SDK but keep a thin HTTP layer (e.g. FastAPI) in front. The A2A
+  framing is out of scope for this skill — port the agent behind it and flag the boundary so the
+  user re-wires transport if they need it.
+
+Do **not** silently delete an A2A server and pretend the topology is unchanged — call it out.
+
+## Other non-ADK tool sources
+
+`ToolboxSyncClient` / `toolbox_core` (`load_toolset(...)`) and similar dynamic tool registries are
+*not* ADK — they're separate deps that return a list of tools at runtime. The skill doesn't have to
+remove them, but the Anthropic loop needs explicit schemas, so either keep the client and convert
+each loaded tool to an Anthropic schema, or replace it with the underlying functions. Note the
+choice in `INVENTORY.md`.

--- a/.claude/skills/adk-to-anthropic-sdk/references/model-mapping.md
+++ b/.claude/skills/adk-to-anthropic-sdk/references/model-mapping.md
@@ -1,0 +1,26 @@
+# Model Mapping: ADK → Anthropic
+
+ADK projects specify models as Gemini strings, or via `LiteLlm("provider/model")`, or already-Anthropic strings through LiteLlm. Map to a current Anthropic model id by intent, not by exact name.
+
+## Current Anthropic model IDs
+- `claude-opus-4-8` — most capable; use where the source wanted the strongest reasoning model.
+- `claude-sonnet-4-6` — balanced default; use this unless there's a clear reason not to.
+- `claude-haiku-4-5-20251001` — fastest/cheapest; use for high-volume, simple, or latency-sensitive agents.
+
+When in doubt, default to `claude-sonnet-4-6`.
+
+## Heuristic mapping
+
+| Source model string | Map to | Why |
+|----------------------|--------|-----|
+| `gemini-*-pro`, `gemini-2.5-pro`, "pro"/"ultra" tiers | `claude-opus-4-8` | top-tier intent |
+| `gemini-*-flash`, `gemini-2.0-flash`, default mid models | `claude-sonnet-4-6` | balanced default |
+| `gemini-*-flash-lite`, `*-nano`, "lite"/"mini" | `claude-haiku-4-5-20251001` | cheap/fast intent |
+| `LiteLlm("anthropic/claude-...")` | the matching current Claude id | already Anthropic; upgrade to current id |
+| `LiteLlm("openai/...")` or other providers | `claude-sonnet-4-6` (note in INVENTORY) | cross-provider; pick balanced default and flag |
+| unknown / unrecognized | `claude-sonnet-4-6` | safe default |
+
+## Notes
+- Record every mapping decision in `INVENTORY.md` so the user can override (e.g. bump everything to Opus, or pin Haiku for cost).
+- Don't hardcode a model in `agent_runtime.py`; pass it per-`Agent` so different agents can use different tiers exactly as the ADK tree did.
+- These ids are current as of this skill's writing; if a call 404s on model id, the id may have changed — tell the user to check https://docs.claude.com/en/docs/about-claude/models for the latest and update the mapping.

--- a/.claude/skills/adk-to-anthropic-sdk/references/orchestration.md
+++ b/.claude/skills/adk-to-anthropic-sdk/references/orchestration.md
@@ -1,0 +1,105 @@
+# Orchestration Recipes
+
+How to rebuild each ADK workflow agent on top of `run_agent()` (from `agent_runtime.py`). Pick the one matching the topology you recorded in `INVENTORY.md`.
+
+## Sequential (was `SequentialAgent`)
+
+Each agent feeds the next. Replace ADK session `output_key` with a plain dict.
+
+```python
+def pipeline(query):
+    state = {}
+    state["research"] = researcher.run(query)
+    state["draft"]    = writer.run(f"Write based on:\n{state['research']}")
+    state["final"]    = editor.run(f"Polish:\n{state['draft']}")
+    return state["final"]
+```
+
+Where `researcher`, `writer`, `editor` are `Agent` instances. Thread the prior output into the next prompt exactly as ADK passed state.
+
+**Short-circuit guards.** If a stage can stop the pipeline — e.g. a security/judge agent that
+returns `"BLOCKED"` so downstream stages don't run — port that conditional, don't just thread
+output→input:
+
+```python
+def secure_pipeline(query):
+    verdict = judge.run(query)
+    if "BLOCKED" in verdict:
+        return verdict                      # stop early, exactly as ADK did
+    result = sql_agent.run(query)
+    return mask_agent.run(result)
+```
+
+Losing the guard is a silent behavior change — the masker/SQL stage would run on input the judge
+meant to reject.
+
+## Parallel (was `ParallelAgent`)
+
+Run independent agents concurrently with the async runtime, then merge.
+
+```python
+import asyncio
+
+async def fan_out(query):
+    results = await asyncio.gather(
+        agent_a.arun(query),
+        agent_b.arun(query),
+        agent_c.arun(query),
+    )
+    return merge(results)   # however ADK combined them (concat, vote, summarizer agent)
+```
+
+If ADK fed the gathered outputs into a final synthesizer agent, call that synthesizer after the gather.
+
+## Loop (was `LoopAgent`)
+
+Repeat until a cap or an exit condition. ADK loops exit on `max_iterations` or an escalation signal (often a tool that sets `escalate=True`, or a checker agent returning a sentinel).
+
+```python
+def refine(initial, max_iterations=5):
+    current = initial
+    for i in range(max_iterations):
+        current = refiner.run(f"Improve this:\n{current}")
+        if is_good_enough(current):   # port the ADK exit predicate
+            break
+    return current
+```
+
+Preserve the original termination logic precisely — both the iteration cap and the condition.
+
+## Delegation (was `sub_agents` / `AgentTool`)
+
+The orchestrator decides at runtime which sub-agent to invoke. Expose each sub-agent as a tool.
+
+```python
+def make_delegation_tools():
+    schemas = [
+        {"name": "ask_billing", "description": "Handle billing questions.",
+         "input_schema": {"type": "object",
+                          "properties": {"query": {"type": "string"}},
+                          "required": ["query"]}},
+        {"name": "ask_tech", "description": "Handle technical support.",
+         "input_schema": {"type": "object",
+                          "properties": {"query": {"type": "string"}},
+                          "required": ["query"]}},
+    ]
+    handlers = {
+        "ask_billing": lambda query: billing_agent.run(query),
+        "ask_tech":    lambda query: tech_agent.run(query),
+    }
+    return schemas, handlers
+
+schemas, handlers = make_delegation_tools()
+answer = orchestrator.run(user_query, extra_tools=schemas, extra_handlers=handlers)
+```
+
+The orchestrator's tool-use loop now delegates by calling these tools. If delegation in the source was static (always the same order, no LLM decision), just call the sub-agents directly instead — simpler and faithful.
+
+## Choosing
+- One agent, some tools → no orchestration file, just `agent.run(...)`.
+- Fixed order → Sequential.
+- Independent + merge → Parallel.
+- Repeat-until → Loop.
+- LLM-decided routing → Delegation.
+
+Combine freely (a pipeline whose middle step is a loop, etc.) to match the source tree.

--- a/.claude/skills/adk-to-anthropic-sdk/references/sdk-tool-loop.md
+++ b/.claude/skills/adk-to-anthropic-sdk/references/sdk-tool-loop.md
@@ -1,0 +1,55 @@
+# Anthropic Tool-Use Loop
+
+The core primitive every ported agent uses. The model may ask to call tools; you run them and feed results back until it stops requesting tools.
+
+## Minimal shape
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic()  # reads ANTHROPIC_API_KEY
+
+def run_agent(system, tools, tool_handlers, user_input, model="claude-sonnet-4-6", max_turns=10):
+    messages = [{"role": "user", "content": user_input}]
+    for _ in range(max_turns):
+        resp = client.messages.create(
+            model=model,
+            max_tokens=4096,
+            system=system,
+            tools=tools,             # list of tool schemas (may be empty)
+            messages=messages,
+        )
+        messages.append({"role": "assistant", "content": resp.content})
+
+        if resp.stop_reason != "tool_use":
+            # final answer: concatenate text blocks
+            return "".join(b.text for b in resp.content if b.type == "text")
+
+        # run each requested tool, collect results
+        tool_results = []
+        for block in resp.content:
+            if block.type == "tool_use":
+                handler = tool_handlers[block.name]
+                try:
+                    output = handler(**block.input)
+                    result = {"type": "tool_result", "tool_use_id": block.id,
+                              "content": str(output)}
+                except Exception as e:
+                    result = {"type": "tool_result", "tool_use_id": block.id,
+                              "content": f"Error: {e}", "is_error": True}
+                tool_results.append(result)
+        messages.append({"role": "user", "content": tool_results})
+    return "".join(b.text for b in messages[-1]["content"] if getattr(b, "type", None) == "text")
+```
+
+## Key rules
+- Append the assistant's **full `content` list** (text + tool_use blocks) back into messages, not just text.
+- Every `tool_use` block in a turn must be answered by a `tool_result` with the matching `tool_use_id` in the next user message — answer all of them before the next `create` call.
+- `max_tokens` is required on every call.
+- Set `system` as a top-level kwarg, not as a message.
+- Cap turns (`max_turns`) so a misbehaving loop can't run forever — mirror any ADK `max_iterations` here.
+
+## Async variant
+Use `AsyncAnthropic` and `await client.messages.create(...)` for parallel orchestration. Tool handlers can stay sync (call them directly) or be awaited if they're coroutines.
+
+`agent_runtime.py` packages all of this so ports don't copy the loop by hand.

--- a/.claude/skills/adk-to-anthropic-sdk/references/verification.md
+++ b/.claude/skills/adk-to-anthropic-sdk/references/verification.md
@@ -1,0 +1,38 @@
+# Verification
+
+`scripts/verify_port.py <port-dir>` is the "error-free" guarantee. It runs four stages, cheapest first, and prints PASS/FAIL for each plus a final summary. Run it after every translation pass and fix until green.
+
+## Stages
+
+1. **Syntax** — `compile(source, path, "exec")` on every `.py` under the port dir. Any `SyntaxError` is reported with file and line.
+
+2. **Imports (mocked)** — each module is imported in a fresh subprocess with a fake `anthropic` package injected via `sys.modules` before import. This means:
+   - no real API key needed,
+   - no network calls,
+   - missing names, bad imports, and leftover `google.adk` imports surface as `ImportError`/`ModuleNotFoundError`.
+   The fake exposes `Anthropic`, `AsyncAnthropic`, and the response shape the runtime expects.
+
+3. **ADK residue scan** — greps every `.py` for `google.adk`, `from google import adk`, common ADK symbols (`LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent`, `FunctionTool`, `AgentTool`), the MCP-toolset wiring (`MCPToolset`, `StdioServerParameters`), and `google.genai` (the `types.Content`/`types.Part` helpers). Any hit in live code (comments/strings are stripped first) fails the stage — these dependencies must be gone.
+
+4. **Mocked dry run** — if an entry point is detected (a top-level `main`/`run`/`pipeline`/`orchestrate` function, **sync or `async def`**), the script executes it against a `FakeAnthropic` client. Coroutine entry points are awaited with `asyncio.run` — a coroutine that's created but never awaited would otherwise PASS without running the orchestration at all (the common ADK shape, since ADK is `run_async`-based). that returns scripted responses: first a tool_use block (if the agent has tools) then a final text block. This exercises orchestration, tool dispatch, message threading, and termination without spending tokens. Failures (unhandled exceptions, infinite-loop guard trip, KeyErrors on tool dispatch) are reported with traceback.
+
+## How the mock works
+
+The fake client mimics the subset of the SDK the runtime touches:
+- `messages.create(...)` returns an object with `.content` (a list of blocks with `.type`, `.text`, `.name`, `.input`, `.id`) and `.stop_reason`.
+- It alternates: if `tools` were passed and it hasn't "used" one yet this call-sequence, it returns a `tool_use` block; otherwise a `text` block with `stop_reason="end_turn"`.
+- `AsyncAnthropic.messages.create` is the async twin.
+
+This is enough to drive any port built on `agent_runtime.py`. If a port uses the SDK directly in an unusual way, extend `FakeAnthropic` in the script (it's small and documented inline).
+
+## Extending the dry run
+
+Auto-detection covers the common cases. For an unusual entry point, pass `--entry "module:function"` to point the verifier at it, or `--entry-arg "some input"` to supply the initial query. If a port needs richer fake responses (specific tool outputs to flow correctly), add cases to `FakeAnthropic._next_response()`.
+
+## Live smoke test
+
+Separate from `verify_port.py`. Only when the user asks and `ANTHROPIC_API_KEY` is set: run the real entry point once with a trivial input and the cheapest model (`claude-haiku-4-5-20251001`) to confirm real connectivity. Keep it to a single short call.
+
+## Interpreting results
+- All four stages PASS → the port is import-clean, ADK-free, and runs end-to-end under mock. That's the deliverable bar.
+- Any FAIL → read the stage output, fix the specific file, re-run. Don't hand back a port with a failing stage.

--- a/.claude/skills/adk-to-anthropic-sdk/scripts/verify_port.py
+++ b/.claude/skills/adk-to-anthropic-sdk/scripts/verify_port.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+verify_port.py — layered verification for an Anthropic-SDK port.
+
+Stages (cheapest first):
+  1. syntax    : compile() every .py
+  2. imports   : import each module in a subprocess with a MOCK `anthropic`
+  3. adk_scan  : fail if any google.adk residue remains
+  4. dry_run   : execute a detected entry point against a FakeAnthropic client
+
+Usage:
+  python verify_port.py <port-dir>
+  python verify_port.py <port-dir> --entry module:function --entry-arg "hello"
+
+Exit code 0 iff all stages pass.
+"""
+
+import argparse
+import ast
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+GREEN, RED, YELLOW, RESET = "\033[92m", "\033[91m", "\033[93m", "\033[0m"
+ADK_PATTERNS = [
+    "google.adk", "from google import adk",
+    "LlmAgent", "SequentialAgent", "ParallelAgent", "LoopAgent",
+    "FunctionTool", "AgentTool", "google.adk.runners",
+    "MCPToolset", "StdioServerParameters",  # ADK MCP tool wiring must be ported
+    "google.genai",                          # genai types.Content/Part must be gone too
+]
+
+# ---- the mock anthropic package, written to a temp dir and put on sys.path ----
+MOCK_ANTHROPIC = '''
+"""Mock anthropic package for offline verification."""
+
+class _Block:
+    def __init__(self, type, text=None, name=None, input=None, id=None):
+        self.type = type; self.text = text; self.name = name
+        self.input = input or {}; self.id = id
+
+class _Resp:
+    def __init__(self, content, stop_reason):
+        self.content = content; self.stop_reason = stop_reason
+
+class _Messages:
+    def __init__(self): self._call = 0
+    def create(self, **kw):
+        self._call += 1
+        tools = kw.get("tools")
+        # First call with tools -> request one tool; otherwise finish.
+        if tools and self._call == 1:
+            t = tools[0]
+            props = (t.get("input_schema", {}) or {}).get("properties", {})
+            fake_input = {k: "x" for k in props}
+            return _Resp([_Block("tool_use", name=t["name"],
+                                 input=fake_input, id="tu_1")], "tool_use")
+        return _Resp([_Block("text", text="mock final answer")], "end_turn")
+
+class Anthropic:
+    def __init__(self, *a, **k): self.messages = _Messages()
+
+class _AsyncMessages:
+    def __init__(self): self._call = 0
+    async def create(self, **kw):
+        self._call += 1
+        tools = kw.get("tools")
+        if tools and self._call == 1:
+            t = tools[0]
+            props = (t.get("input_schema", {}) or {}).get("properties", {})
+            return _Resp([_Block("tool_use", name=t["name"],
+                                 input={k: "x" for k in props}, id="tu_1")], "tool_use")
+        return _Resp([_Block("text", text="mock final answer")], "end_turn")
+
+class AsyncAnthropic:
+    def __init__(self, *a, **k): self.messages = _AsyncMessages()
+'''
+
+
+def _make_mock_dir(workdir: Path) -> Path:
+    mock_root = workdir / "_mock_pkgs"
+    pkg = mock_root / "anthropic"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text(MOCK_ANTHROPIC)
+    return mock_root
+
+
+def py_files(root: Path):
+    skip = {".git", "__pycache__", "_mock_pkgs", ".venv", "venv", "node_modules"}
+    for p in root.rglob("*.py"):
+        if not any(part in skip for part in p.parts):
+            yield p
+
+
+def stage_syntax(root: Path):
+    errs = []
+    for f in py_files(root):
+        try:
+            compile(f.read_text(), str(f), "exec")
+        except SyntaxError as e:
+            errs.append(f"  {f}:{e.lineno}: {e.msg}")
+    return (not errs), errs
+
+
+def stage_imports(root: Path, mock_root: Path):
+    errs = []
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(mock_root), str(root),
+                                         env.get("PYTHONPATH", "")])
+    env["ANTHROPIC_API_KEY"] = env.get("ANTHROPIC_API_KEY", "mock-key")
+    for f in py_files(root):
+        rel = f.relative_to(root).with_suffix("")
+        mod = ".".join(rel.parts)
+        code = f"import importlib; importlib.import_module({mod!r})"
+        proc = subprocess.run([sys.executable, "-c", code], env=env,
+                              capture_output=True, text=True, cwd=str(root))
+        if proc.returncode != 0:
+            tail = proc.stderr.strip().splitlines()[-3:]
+            errs.append(f"  {mod}:\n" + textwrap.indent("\n".join(tail), "    "))
+    return (not errs), errs
+
+
+def _strip_comments_and_strings(text: str) -> str:
+    """Tokenize and drop comments + string literals so scans only see real code."""
+    import io, tokenize
+    out = []
+    try:
+        toks = tokenize.generate_tokens(io.StringIO(text).readline)
+        for tok in toks:
+            if tok.type in (tokenize.COMMENT, tokenize.STRING):
+                continue
+            out.append((tok.start, tok.string))
+    except (tokenize.TokenError, IndentationError):
+        return text  # fall back to raw text if tokenizing fails
+    return "\n".join(s for _, s in out)
+
+
+def stage_adk_scan(root: Path):
+    hits = []
+    for f in py_files(root):
+        if f.name == "agent_runtime.py":
+            continue  # the runtime references ADK names only in its docstring
+        code_only = _strip_comments_and_strings(f.read_text())
+        for pat in ADK_PATTERNS:
+            if pat in code_only:
+                hits.append(f"  {f}: live code references '{pat}'")
+    return (not hits), hits
+
+
+def detect_entry(root: Path):
+    """Return (module, callable_name, needs_arg) or None."""
+    for f in py_files(root):
+        if f.name == "agent_runtime.py":
+            continue  # never an entry point; it's the runtime library
+        try:
+            tree = ast.parse(f.read_text())
+        except SyntaxError:
+            continue
+        # only top-level (module-scope) functions are valid entry points;
+        # ADK orchestration is usually async, so match `async def` too.
+        funcs = {n.name: n for n in tree.body
+                 if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        rel = f.relative_to(root).with_suffix("")
+        mod = ".".join(rel.parts)
+        for cand in ("main", "run", "pipeline", "orchestrate"):
+            if cand in funcs:
+                args = funcs[cand].args
+                n_required = len(args.args) - len(args.defaults)
+                return (mod, cand, n_required > 0)
+    return None
+
+
+def stage_dry_run(root: Path, mock_root: Path, entry, entry_arg):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(mock_root), str(root),
+                                         env.get("PYTHONPATH", "")])
+    env["ANTHROPIC_API_KEY"] = "mock-key"
+    if entry:
+        mod, fn = entry.split(":")
+        needs_arg = True
+    else:
+        det = detect_entry(root)
+        if not det:
+            return None, ["  no entry point detected (main/run/pipeline). "
+                          "pass --entry module:function to dry-run it."]
+        mod, fn, needs_arg = det
+    arg = repr(entry_arg) if (needs_arg) else ""
+    # If the entry point is a coroutine (async def), await it — otherwise we'd
+    # just create a coroutine object and never run the orchestration (false PASS).
+    code = (
+        "import importlib, inspect, asyncio\n"
+        f"m = importlib.import_module({mod!r})\n"
+        f"r = getattr(m, {fn!r})({arg})\n"
+        "if inspect.isawaitable(r): r = asyncio.run(r)\n"
+        "print('DRYRUN_OK', type(r).__name__)"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], env=env,
+                          capture_output=True, text=True, cwd=str(root), timeout=120)
+    if proc.returncode != 0 or "DRYRUN_OK" not in proc.stdout:
+        tail = (proc.stderr.strip() or proc.stdout.strip()).splitlines()[-8:]
+        return False, [f"  entry {mod}:{fn} failed:\n"
+                       + textwrap.indent("\n".join(tail), "    ")]
+    return True, [f"  ran {mod}:{fn} -> {proc.stdout.strip()}"]
+
+
+def report(name, ok, details):
+    if ok is None:
+        print(f"{YELLOW}SKIP{RESET}  {name}")
+    else:
+        tag = f"{GREEN}PASS{RESET}" if ok else f"{RED}FAIL{RESET}"
+        print(f"{tag}  {name}")
+    for d in details:
+        print(d)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("port_dir")
+    ap.add_argument("--entry", help="module:function to dry-run")
+    ap.add_argument("--entry-arg", default="hello", help="argument for the entry function")
+    args = ap.parse_args()
+
+    root = Path(args.port_dir).resolve()
+    if not root.is_dir():
+        print(f"{RED}error{RESET}: {root} is not a directory"); sys.exit(2)
+
+    mock_root = _make_mock_dir(root)
+    print(f"Verifying port: {root}\n")
+
+    results = []
+    ok, d = stage_syntax(root);            report("1. syntax", ok, d);   results.append(ok)
+    ok, d = stage_imports(root, mock_root);report("2. imports (mocked)", ok, d); results.append(ok)
+    ok, d = stage_adk_scan(root);          report("3. adk residue scan", ok, d); results.append(ok)
+    ok, d = stage_dry_run(root, mock_root, args.entry, args.entry_arg)
+    report("4. dry run (mocked)", ok, d)
+    if ok is not None:
+        results.append(ok)
+
+    print()
+    passed = all(r for r in results if r is not None)
+    if passed:
+        print(f"{GREEN}ALL STAGES PASSED{RESET} — port is syntax-clean, import-clean, "
+              f"ADK-free, and runs end-to-end under mock.")
+        sys.exit(0)
+    else:
+        print(f"{RED}VERIFICATION FAILED{RESET} — fix the reported issues and re-run.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Implemented `agent_runtime.py` providing a reusable agent runtime on top of the Anthropic SDK, including synchronous and asynchronous tool-use loops.
- Created `adk-patterns.md` to map Google ADK constructs to their Anthropic SDK equivalents.
- Added `mcp-and-a2a.md` detailing the handling of MCP toolsets and A2A protocols in the Anthropic SDK.
- Introduced `model-mapping.md` for mapping ADK model specifications to current Anthropic model IDs.
- Developed `orchestration.md` with recipes for rebuilding ADK workflows using the Anthropic SDK.
- Documented the Anthropic tool-use loop in `sdk-tool-loop.md`.
- Added `verification.md` outlining the verification process for ports.
- Implemented `verify_port.py` script for layered verification of Anthropic SDK ports, including syntax checks, import validation, ADK residue scanning, and dry runs.