### PR TITLE
Add Module 5 study-material + conda env setup docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,9 @@ live in that module's `study-material/` subfolder, alongside the module's suppor
 files and pull in the supporting material for hands-on work. Copy `modules/_TEMPLATE/` (whose
 five files become the module's `study-material/`) when adding a new module.
 
-> Note: `Module_1_Agent_Loop` and `Module_2_Skills_Sub_Agents` currently have the full
-> `study-material/` set. The other modules so far contain only supporting material (notebooks,
-> code, READMEs); their teaching files still need to be authored.
+> Note: `Module_1_Agent_Loop`, `Module_2_Skills_Sub_Agents`, and `Module_5_Multi_Agents`
+> currently have the full `study-material/` set. The remaining modules so far contain only
+> supporting material (notebooks, code, READMEs); their teaching files still need to be authored.
 
 ## Teaching style
 

--- a/modules/Module_5_Multi_Agents/README.md
+++ b/modules/Module_5_Multi_Agents/README.md
@@ -54,8 +54,9 @@ Module_5_Multi_Agents/
 ```
 
 > **Note:** This module is taught primarily through the hands-on project below, with one supporting
-> notebook (see *Companion Notebook* next). The other modules' `study-material/` lesson files are the
-> conceptual companion; here the system *is* the lesson.
+> notebook (see *Companion Notebook* next). The conceptual companion lives in
+> [`study-material/`](study-material/) — `lesson.md`, `key-concepts.md`, `exercises.md`, `quiz.md`,
+> and `recap-and-preview.md` — but here the system *is* the lesson: read the concepts, then go run it.
 
 ---
 
@@ -108,6 +109,22 @@ How the pieces map to the module's concepts:
 The project's own [`README.md`](advance-customer-support-agent-feature-A2A-MCP-ADK/README.md) has the
 full prerequisites, step-by-step setup (PostgreSQL, MCP Toolbox, A2A servers, the CLI), the request
 flow, and a troubleshooting guide. Start there once you've got the conceptual picture above.
+
+---
+
+## Environment Setup
+
+The capstone targets **Python 3.12+**. Create an isolated conda environment before installing:
+
+```bash
+conda create -y -n customer-support python=3.12   # creates Python 3.12.x
+conda activate customer-support
+cd advance-customer-support-agent-feature-A2A-MCP-ADK
+pip install -r requirements.txt
+```
+
+See the project [`README.md`](advance-customer-support-agent-feature-A2A-MCP-ADK/README.md#3--python-dependencies)
+for the full dependency setup (Phoenix observability + OTel pinning).
 
 ---
 

--- a/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/README.md
+++ b/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/README.md
@@ -43,6 +43,13 @@ MEM0_API_KEY=<your Mem0 key>                 # mem0.ai
 
 ## 3 — Python Dependencies
 
+Create an isolated conda environment (Python 3.12, matching the prerequisite) and install into it:
+
+```bash
+conda create -y -n customer-support python=3.12
+conda activate customer-support
+```
+
 ```bash
 pip install -r requirements.txt
 

--- a/modules/Module_5_Multi_Agents/study-material/exercises.md
+++ b/modules/Module_5_Multi_Agents/study-material/exercises.md
@@ -1,0 +1,61 @@
+# Module 05 — Exercises
+
+<!-- INSTRUCTOR: Hands-on tasks for the build-along skill. Goal first, then steps,
+     then a "done when" check. Grounded in the capstone project. Exercises work even
+     without the full stack running — they're about reading and reasoning about the
+     protocol layer, with optional run-it stretches. -->
+
+## Exercise 1 — Read an agent card and trace a call
+
+**Goal:** Understand what A2A publishes and how a call actually travels.
+
+**Steps:**
+1. Open `cs_agent/a2a/factories.py`. Find `create_judge_server` and read its `AgentCard`.
+2. Write down four things a caller learns from that card: its **URL**, its **capabilities**, its
+   **skill**, and its **input/output modes**.
+3. Open `cs_agent/a2a/client.py`. In `_call_sync`, identify the JSON-RPC **method**, the **URL**
+   it posts to, and where the user's text sits in the payload.
+4. In one sentence, explain how the CLI reaches the Judge *without importing the Judge's code*.
+
+**Done when:** You can name the JSON-RPC method (`tasks/send`), the port (`10002`), and explain
+that the agent card — not a Python import — is the contract between caller and agent.
+
+**Stretch (optional):** Start the A2A servers (`python -m cs_agent.a2a.run_servers`) and
+`curl` a `tasks/send` request to `http://localhost:10002/rpc` with a benign message, then a
+SQL-injection-looking one, and compare the verdicts.
+
+## Exercise 2 — Add a new MCP tool
+
+**Goal:** Prove that tools live in the MCP server's config, not the agent's code.
+
+**Steps:**
+1. Open `mcp_toolbox/tools.yaml`. Read how an existing tool (e.g. `get-order-status`) is
+   defined — its name, its SQL statement, its parameters.
+2. Define a new read-only tool, e.g. `get-recent-orders`, that returns the N most recent orders
+   across all users (or by status). Write only the YAML — no Python.
+3. Note in `cs_agent/prompts.py` where you'd add a usage guideline so the agent knows when to
+   call your new tool.
+4. Explain why you did **not** have to edit the agent's Python to add a tool.
+
+**Done when:** You have a valid tool entry in `tools.yaml` and can articulate that the agent
+discovers it at runtime via `load_toolset`, so no agent code changed.
+
+**Stretch (optional):** Run the full stack and ask the agent a question that should trigger your
+new tool. Watch it discover and call the tool you only declared in YAML.
+
+## Exercise 3 — Map the security pipeline
+
+**Goal:** Trace defense-in-depth across the three layers and justify the ordering.
+
+**Steps:**
+1. In `cs_agent/agent_cli.py`, read `validate_input()` (Layers 1 and 2) and `_mask_response()`.
+2. Draw the path of one message: input → sanitize → A2A Judge → agent → A2A Mask → output.
+   Label which layer is **local**, which is **LLM-powered**, and which protocol carries each.
+3. For each layer, write the one threat it's there to stop.
+4. Argue: why is sanitize **before** the Judge, and masking on the **output** side?
+
+**Done when:** Your diagram shows all three layers with the right protocol on each hop, and you
+can defend the ordering (cheap-before-expensive on input; PII can only leak on output).
+
+**Stretch (optional):** The Judge returns the message unmodified or `"BLOCKED"`. What failure
+mode appears if the A2A Judge server is down — and how does `_check_a2a_servers()` handle it?

--- a/modules/Module_5_Multi_Agents/study-material/key-concepts.md
+++ b/modules/Module_5_Multi_Agents/study-material/key-concepts.md
@@ -1,0 +1,39 @@
+# Module 05 — Key Concepts (Glossary)
+
+<!-- INSTRUCTOR: Short, accurate definitions Claude uses to stay precise.
+     The explain-eli5 skill reads from here to simplify without becoming wrong. -->
+
+- **Protocol layer** — A small set of shared standards (MCP, A2A, ADK) that let any agent or
+  tool talk to any other the same way, replacing N² point-to-point integration glue.
+- **MCP (Model Context Protocol)** — The standard for exposing *tools and data sources* to an
+  agent. You run an MCP server; the agent discovers and calls its tools at runtime.
+- **MCP server / Toolbox** — A process that publishes operations as tools. In the capstone, the
+  MCP Toolbox wraps PostgreSQL and serves `get-order-status`, `find-customer-orders`,
+  `action-log` from a `tools.yaml` config — the agent loads the toolset, never raw SQL.
+- **A2A (Agent-to-Agent)** — The standard for one agent to invoke *another agent* as an
+  independent service over JSON-RPC 2.0 / HTTP, with optional SSE streaming.
+- **Agent card** — A JSON description an A2A agent publishes: its name, URL, capabilities
+  (e.g. `streaming`), and skills — so callers can discover what it does without importing it.
+- **JSON-RPC 2.0** — The request format A2A uses; method `tasks/send` (sync) or
+  `tasks/sendSubscribe` (SSE streaming), posted to the agent's `/rpc` URL.
+- **ADK (Agent Development Kit)** — Google's framework for *defining* agents: `LlmAgent`,
+  `SequentialAgent`, and the `Runner`.
+- **`LlmAgent`** — A single ADK agent: a model (`gemini-2.5-flash`), an `instruction` (its system
+  prompt), and a list of `tools`. The support agent, Judge, and Masker are each one.
+- **`SequentialAgent`** — An ADK agent that runs its `sub_agents` in order. The capstone's
+  `security_pipeline` chains `[judge_agent, mask_agent]`.
+- **`Runner`** — The ADK component that drives an agent: manages the session, feeds the user
+  message, and streams events until `is_final_response()`. It runs the agent loop for you.
+- **Compose rule** — **ADK defines, A2A connects, MCP feeds.** Each layer is independently
+  swappable without touching the others.
+- **Security pipeline** — Defense in depth around the agent: `sanitize_input()` (local) → A2A
+  Security Judge (LLM + 100+ regex → pass or `BLOCKED`) → the agent → A2A Data Masker (Cloud DLP
+  PII masking on output).
+- **Security Judge** — An A2A `LlmAgent` (port `10002`) that evaluates input for SQL injection,
+  XSS, and other threats, returning the message unchanged or `BLOCKED`.
+- **Data Masker** — An A2A `LlmAgent` (port `10003`) that masks PII in the agent's output via
+  Google Cloud DLP before it reaches the user.
+- **Mem0** — Persistent, cross-session memory the support agent searches by `USER_ID` to recall
+  past conversations and preferences.
+- **Startup order** — PostgreSQL → MCP Toolbox → A2A servers → (Phoenix) → agent. Each service
+  depends on the one before it; the CLI refuses to start if the A2A servers are unreachable.

--- a/modules/Module_5_Multi_Agents/study-material/lesson.md
+++ b/modules/Module_5_Multi_Agents/study-material/lesson.md
@@ -1,0 +1,163 @@
+# Module 05 — Multi-Agent Systems & the Protocol Layer
+
+<!-- INSTRUCTOR: This is the teaching content Claude walks the learner through.
+     Each ## is roughly one "concept" Claude presents, then checks understanding on.
+     Source: the capstone project advance-customer-support-agent-feature-A2A-MCP-ADK
+     (the system IS the lesson) + the module README. Keep chunks short. -->
+
+## Learning objectives
+
+By the end of this module the learner can:
+- [ ] Explain why a **protocol layer** beats bespoke glue code once you have >1 agent or tool
+- [ ] Describe **MCP** and why exposing tools through an MCP server beats hard-coding them
+- [ ] Describe **A2A** — agent cards, JSON-RPC over HTTP — and when to run an agent as a service
+- [ ] Describe **ADK** primitives: `LlmAgent`, `SequentialAgent`, and the `Runner`
+- [ ] Explain how the three layers compose: ADK *defines*, A2A *connects*, MCP *feeds*
+- [ ] Trace the capstone's security pipeline (sanitize → A2A judge → agent → A2A mask) end to end
+
+## Prerequisites
+- Module 2 (orchestrator + subagents, isolated context, specialization). This module replaces
+  in-process subagents with agents that talk **over the network** through shared protocols.
+
+---
+
+## Concept 1 — Why a protocol layer
+
+[In Module 2 the orchestrator and its subagents lived in one process — the orchestrator
+*spawned* them directly. That works until agents are built by different teams, written in
+different frameworks, or need to run as separate services that scale independently. Then every
+new connection is custom glue: agent A learns agent B's function signature, C learns D's API,
+and you get an N² tangle of point-to-point integrations that breaks whenever anything moves.
+
+A **protocol layer** is the fix: a small set of *standards* so any agent or tool talks to any
+other the same way, regardless of who built it. Think USB — you don't rewire your laptop for
+each device; you agree on a plug. Module 5 teaches the three plugs that matter: **MCP** (how
+agents get tools), **A2A** (how agents call other agents), and **ADK** (how agents are
+defined). The throughline: standards replace glue.]
+
+**Check:** What goes wrong with point-to-point integration once you have several agents and
+tools, and what does a protocol layer replace it with?
+
+## Concept 2 — MCP: the standard way to give an agent tools
+
+[**MCP (Model Context Protocol)** is the standard for exposing *tools and data sources* to an
+agent. Instead of baking a database call into your agent's code, you run an **MCP server** that
+publishes the operations as tools; the agent **discovers them at runtime** and calls them.
+
+In the capstone, the **MCP Toolbox** server wraps PostgreSQL and publishes a toolset —
+`get-order-status`, `find-customer-orders`, `action-log` — defined in a `tools.yaml` config, not
+in Python. The agent loads the toolset on startup (`toolbox_client.load_toolset("cs_agent_tools")`)
+and never sees raw SQL. Why this matters: the tools become swappable and reusable. Change the
+database, fix a query, add a tool — you edit the MCP server's config, and *every* agent that
+points at it gets the change. The agent code doesn't move.]
+
+**Check:** In the capstone, where do the database operations live — in the agent's code or
+somewhere else? What does the agent do to get them?
+
+## Concept 3 — A2A: the standard way for agents to call agents
+
+[**A2A (Agent-to-Agent)** is the standard for one agent to invoke *another agent* as an
+independent service. Each agent publishes an **agent card** — a small JSON description of its
+name, URL, capabilities (e.g. streaming), and skills — so callers can discover what it does.
+Others invoke it over **JSON-RPC 2.0 / HTTP** (method `tasks/send`, or `tasks/sendSubscribe`
+for SSE streaming).
+
+In the capstone, the **Security Judge** runs as its own server on port `10002` and the **Data
+Masker** on `10003`. The CLI doesn't import them — it POSTs a JSON-RPC request to their URLs for
+every message, and *refuses to start* if they're unreachable. That's the A2A shift from Module
+2: a subagent there was an in-process spawn; an A2A agent is a **network service** with a
+published contract. It can be written in any language, deployed separately, and scaled on its
+own — the caller only needs its agent card.]
+
+**Check:** What's in an agent card, and how is calling an A2A agent different from spawning a
+Module-2 subagent?
+
+## Concept 4 — ADK: the standard way to define an agent
+
+[**ADK (Agent Development Kit)** is Google's framework for *defining* the agents themselves.
+Three primitives carry the module:
+- **`LlmAgent`** — a single agent: a model (`gemini-2.5-flash`), an `instruction` (its system
+  prompt), and a list of `tools`. The capstone's support agent, Judge, and Masker are each one.
+- **`SequentialAgent`** — chains sub-agents so they run in order. The capstone's
+  `security_pipeline` is `SequentialAgent(sub_agents=[judge_agent, mask_agent])` — Judge first,
+  Masker second.
+- **`Runner`** — the thing that actually *drives* an agent: it manages the session, feeds in the
+  user message, and streams back events until `is_final_response()`. You don't call the model
+  directly; the Runner runs the loop (that's the Module 1 agent loop, now framework-managed).
+
+So ADK is the *definition* layer — it says what an agent is and how it executes.]
+
+**Check:** Match each to its job: `LlmAgent`, `SequentialAgent`, `Runner`. Which one runs the
+loop that drives the agent?
+
+## Concept 5 — How the three layers compose
+
+[The point of the capstone is that these aren't three separate topics — they're three layers of
+one system:
+
+    ADK   defines the agents      (LlmAgent: support, Judge, Masker; SequentialAgent pipeline)
+    A2A   connects the agents     (Judge :10002 and Masker :10003 as JSON-RPC services)
+    MCP   feeds the agents tools  (Toolbox server publishes the Postgres toolset)
+
+Read it as one sentence: **ADK defines them, A2A connects them, MCP feeds them.** Each layer is
+independent — you can swap the database behind MCP, rewrite the Judge in another language behind
+A2A, or change the support agent's model in ADK — without touching the others. That
+independence is exactly what the protocol layer buys you, and it's why this is the "action" end
+of the course: agents stop being standalone chatbots and start coordinating as a system.]
+
+**Check:** Say in one sentence what each layer does for the capstone, using the words define,
+connect, feed.
+
+## Concept 6 — Security as a pipeline of agents
+
+[The capstone wraps the support agent in a **multi-layer security pipeline** — and the security
+checks are *themselves agents*, reached over A2A. The flow around every user message:
+
+    user input
+      ↓  Layer 1: sanitize_input()      local — character whitelist, length cap, Model Armor
+      ↓  Layer 2: A2A Security Judge     :10002 — LlmAgent + 100+ regex patterns → pass or "BLOCKED"
+      ↓  the support agent               ADK LlmAgent + MCP tools + Mem0 memory
+      ↓  Layer 3: A2A Data Masker        :10003 — Google Cloud DLP masks PII on the way out
+    response to user
+
+Note the shape: a cheap **local** check first (sanitize), then an **LLM-powered** check
+(the Judge reasons *and* runs regex via a tool), then the agent, then masking on output. Defense
+in depth — each layer catches what the previous can't, and the Judge being a separate A2A
+service means you can harden or replace it without redeploying the support agent.]
+
+**Check:** Why run a cheap local `sanitize_input()` before calling the LLM-powered Judge, rather
+than just the Judge? And why is masking on the *output* side, not the input?
+
+## Concept 7 — The capstone end to end
+
+[Put it together. A user logs in (one of the seeded test users), and for each message:
+1. **Sanitize** locally; reject garbage early.
+2. **Judge** over A2A — block injection/XSS attempts before they reach the model.
+3. The **support agent** (ADK `LlmAgent`) reasons, recalls history from **Mem0**, and calls
+   **MCP** tools to read orders or log an action — note it *logs* write-intents to `actions_log`
+   rather than mutating core tables directly.
+4. **Mask** the response over A2A so no PII leaks out.
+
+To run it you start five things *in order* — PostgreSQL → MCP Toolbox → A2A servers → (Phoenix
+observability) → the agent — because each depends on the one before. That startup order is the
+dependency graph of the protocol layer made visible: tools must exist before agents can load
+them, and the A2A services must be up before the CLI that calls them will start.]
+
+**Check:** Why does startup order matter — what breaks if you start the agent CLI before the
+MCP Toolbox and the A2A servers?
+
+---
+
+## Summary
+1. A **protocol layer** (MCP, A2A, ADK) replaces N² point-to-point glue with standards, so any
+   agent or tool talks to any other the same way.
+2. **ADK defines** agents (`LlmAgent`, `SequentialAgent`, `Runner`), **A2A connects** them as
+   network services (agent cards + JSON-RPC), **MCP feeds** them discoverable tools — and the
+   three layers are independently swappable.
+3. The capstone proves it: a support agent wrapped in a sanitize → A2A-Judge → agent → A2A-Mask
+   pipeline, with orders served through MCP and memory through Mem0.
+
+## Where to next
+- Do `exercises.md` (read an agent card, then add an MCP tool), or ask to be quizzed
+  (`quiz.md`). To see it run, follow the project `README.md` and start the five services in
+  order.

--- a/modules/Module_5_Multi_Agents/study-material/quiz.md
+++ b/modules/Module_5_Multi_Agents/study-material/quiz.md
@@ -1,0 +1,51 @@
+# Module 05 — Quiz
+
+<!-- INSTRUCTOR: The quiz-me skill uses these. Answers are here so Claude can check,
+     but the rule is Claude NEVER shows them before the learner attempts. Hint first. -->
+
+## Q1. What problem does a protocol layer solve, and what does it replace?
+- Type: explain-why
+- **Answer:** Without it, every agent-to-agent and agent-to-tool connection is custom glue — an
+  N² tangle of point-to-point integrations that breaks when anything moves. A protocol layer
+  replaces that with shared *standards* (MCP, A2A, ADK) so any agent or tool talks to any other
+  the same way, regardless of who built it.
+- **Hint:** Think about what happens to the number of connections as agents and tools multiply.
+
+## Q2. In the capstone, where do the database operations live, and how does the agent get them?
+- Type: recall
+- **Answer:** Not in the agent's code — they live in the **MCP Toolbox** server, defined in
+  `tools.yaml` (`get-order-status`, `find-customer-orders`, `action-log`). The agent
+  **discovers them at runtime** by loading the toolset (`load_toolset("cs_agent_tools")`) and
+  never touches raw SQL.
+- **Hint:** The agent doesn't import SQL; it asks a server what tools exist.
+
+## Q3. How is calling an A2A agent different from spawning a Module-2 subagent?
+- Type: application
+- **Answer:** A Module-2 subagent is an in-process spawn by the orchestrator. An A2A agent is an
+  independent **network service** with a published **agent card**, called over JSON-RPC / HTTP
+  (e.g. the Judge on `:10002`). It can be in any language, deployed and scaled separately; the
+  caller only needs its card, not its code.
+- **Hint:** One lives in the same process; one lives behind a URL.
+
+## Q4. Match each ADK primitive to its job: `LlmAgent`, `SequentialAgent`, `Runner`.
+- Type: recall
+- **Answer:** `LlmAgent` = a single agent (model + instruction + tools). `SequentialAgent` =
+  runs its sub-agents in order (e.g. Judge → Mask). `Runner` = drives an agent — manages the
+  session, feeds the message, and streams events until the final response (it runs the loop).
+- **Hint:** One *is* an agent, one *chains* agents, one *executes* an agent.
+
+## Q5. Summarize how MCP, A2A, and ADK compose, using the words define, connect, feed.
+- Type: explain-why
+- **Answer:** **ADK defines** the agents (`LlmAgent`, `SequentialAgent`, `Runner`); **A2A
+  connects** them as network services (agent cards + JSON-RPC, Judge and Masker on their own
+  ports); **MCP feeds** them tools (the Toolbox publishes the Postgres toolset). Each layer is
+  independently swappable without touching the others.
+- **Hint:** Three verbs, three layers — one each.
+
+## Q6. The security pipeline runs sanitize → Judge → agent → Mask. Why is sanitize before the Judge, and why is masking on the output?
+- Type: application
+- **Answer:** `sanitize_input()` is a cheap **local** check (character whitelist, length,
+  Model Armor) — run it first to reject obvious garbage before paying for an LLM call to the
+  Judge. Masking is on the **output** because PII can only leak in what the agent *says back*;
+  Google Cloud DLP strips it on the way out, after the agent has produced its response.
+- **Hint:** Cheap-before-expensive on the way in; PII can only escape on the way out.

--- a/modules/Module_5_Multi_Agents/study-material/recap-and-preview.md
+++ b/modules/Module_5_Multi_Agents/study-material/recap-and-preview.md
@@ -1,0 +1,35 @@
+# Module 05 — Recap & Preview (15-Minute Warm-Up)
+
+<!-- INSTRUCTOR: A quick "before class" bridge. Recaps Module 04 and previews Module 05.
+     Designed for a ~15-min review with Claude right before the live session.
+     Note: Module 04 (AI Evaluation) recap is best-effort — its study-material isn't authored
+     yet, so keep the recap light and lean on the course arc. -->
+
+## Last time (Module 04 — AI Evaluation)
+The big ideas you should still have in your head:
+- Production **guardrails** (e.g. Llama Guard) sit around the model to catch unsafe input/output.
+- **Trajectory vs. outcome** evaluation — judge the *path* an agent took, not just the final answer.
+- You can't ship what you can't measure: evaluation is what makes an agent safe to put in front of users.
+
+**Quick gut-check:** What's the difference between evaluating an agent's *outcome* and its
+*trajectory*, and why might a right answer reached the wrong way still be a problem?
+
+## How it connects
+Module 4 was about *judging* one agent's behavior. Module 5 is about *coordinating many* — and
+notice the capstone's Security Judge is exactly a guardrail from Module 4, now running as its own
+networked agent. Evaluation becomes a service in the pipeline, not an afterthought.
+
+## Coming up (Module 05 — Multi-Agent Systems & the Protocol Layer)
+What you'll be able to do after today:
+- Explain why a **protocol layer** beats hand-written glue once you have more than one agent or tool
+- Use **MCP** to give an agent tools it discovers at runtime (instead of hard-coding them)
+- Run agents as **A2A** services that publish an agent card and talk over JSON-RPC
+- Define agents with **ADK** — `LlmAgent`, `SequentialAgent`, the `Runner`
+- Trace the capstone: sanitize → A2A Judge → agent (+ MCP tools, Mem0) → A2A Mask
+
+**Watch for:** the one-sentence rule that ties it together — **ADK defines, A2A connects, MCP
+feeds.** If you can say what each layer does for the support agent, the whole system clicks.
+
+## If you only remember one thing walking into class
+> Multi-agent systems scale through *standards*, not glue: ADK defines the agents, A2A connects
+> them over the network, MCP feeds them tools — each layer swappable without touching the others.


### PR DESCRIPTION
## What

Authors the missing teaching files for **Module 5 (Multi-Agent Systems & the Protocol Layer)** and documents conda environment setup for the capstone.

### Study-material (new)
The full set under `modules/Module_5_Multi_Agents/study-material/`, matching the Module 1/2 format and grounded in the actual A2A/MCP/ADK capstone code:
- `lesson.md` — 7 concepts: protocol layer → MCP → A2A → ADK → composition → security pipeline → end-to-end flow
- `key-concepts.md` — glossary (agent card, JSON-RPC, `LlmAgent`/`SequentialAgent`/`Runner`, define/connect/feed)
- `exercises.md` — 3 hands-on tasks (read an agent card, add an MCP tool, map the security pipeline)
- `quiz.md` — 6 questions with hidden answers + hints
- `recap-and-preview.md` — 15-min warm-up bridging from Module 4

### Docs
- Conda env setup (`customer-support`, Python 3.12) added to the Module 5 README and the project README's dependency section
- Updated the stale notes in `CLAUDE.md` and the Module 5 README that claimed this module had no teaching files

🤖 Generated with [Claude Code](https://claude.com/claude-code)