### PR TITLE
Module 5: fix .env footgun, document Phoenix + CLI, add handoff

### DIFF
--- a/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/README.md
+++ b/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/README.md
@@ -43,6 +43,9 @@ MEM0_API_KEY=<your Mem0 key>                 # mem0.ai
 
 ## 3 — Python Dependencies
 
+> **Shortcut:** `./run.sh setup` does everything in this section *and* section 4 (env, deps,
+> Postgres, seed, `.env` template) in one step. The manual steps below are for reference.
+
 Create an isolated conda environment (Python 3.12, matching the prerequisite) and install into it:
 
 ```bash
@@ -55,12 +58,12 @@ pip install -r requirements.txt
 
 # Observability (Phoenix + OpenTelemetry)
 pip install arize-phoenix openinference-instrumentation-google-genai \
-    opentelemetry-sdk opentelemetry-exporter-otlp-proto-http \
     openinference-semantic-conventions
 
-# Pin OTel back to ADK-compatible version
-pip install opentelemetry-sdk==1.33.1 \
-    opentelemetry-exporter-otlp-proto-http==1.33.1
+# Pin the OTel family to the version google-adk requires (>=1.39,<=1.42.1).
+pip install opentelemetry-sdk==1.42.1 opentelemetry-api==1.42.1 \
+    opentelemetry-exporter-otlp-proto-http==1.42.1 \
+    opentelemetry-semantic-conventions==0.63b1
 ```
 
 ---
@@ -157,71 +160,155 @@ GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO toolbox_user;
 
 ---
 
-## 5 — Run (4 terminals)
+## 5 — Run
+
+### Option A — one command (recommended)
+
+A helper script, [`run.sh`](run.sh), orchestrates the whole stack in dependency order and
+drops you straight into the agent CLI. From the project root:
+
+```bash
+./run.sh            # PostgreSQL → MCP Toolbox → A2A servers → agent CLI
+```
+
+It health-checks each service before launching the next, and tears the background services
+down automatically when you exit the CLI (Ctrl-C). Other subcommands:
+
+```bash
+./run.sh setup      # one-time: create env, install deps + Postgres, init DB, seed, write .env
+./run.sh stop       # stop background services (Toolbox, A2A, Postgres)
+./run.sh status     # show what's up
+./run.sh seed       # re-seed the database to a known state
+./run.sh logs       # tail the Toolbox + A2A logs
+```
+
+> First time on this machine? Run `./run.sh setup` once, fill `GOOGLE_API_KEY` and
+> `MEM0_API_KEY` in `.env`, then `./run.sh`. See the **Platform support** note at the top of
+> `run.sh` for Windows (WSL/Git Bash).
+
+### Option B — four terminals (manual)
 
 Open four terminal tabs from the project root.
 
 **Terminal 1 — MCP Toolbox**
 ```bash
-npx @toolbox-sdk/server --tools-file mcp_toolbox/tools.yaml --enable-api
+npx @toolbox-sdk/server --config mcp_toolbox/tools.yaml --enable-api --address 127.0.0.1 --port 5000
 ```
-Starts on `http://127.0.0.1:5000`. Wait for `Serving on ...` before continuing.
+Starts on `http://127.0.0.1:5000`. Wait for `Server ready to serve!` before continuing.
 
 **Terminal 2 — A2A Security Servers**
 ```bash
 python -m cs_agent.a2a.run_servers
 ```
-Starts Judge (`:10002`) and Mask (`:10003`). Wait for both `Started server on ...` lines.
+Starts Judge (`:10002`) and Mask (`:10003`). Wait for both `Uvicorn running on ...` lines.
 
-**Terminal 3 — Phoenix Observability** *(optional)*
-```bash
-python - <<'EOF'
-import phoenix as px
-app = px.launch_app()
-print("Phoenix running at http://localhost:6006")
-while True:
-    __import__("time").sleep(60)
-EOF
-```
-Dashboard at `http://localhost:6006`.
-
-**Terminal 4 — Agent**
+**Terminal 3 — Agent**
 ```bash
 cd cs_agent
 python agent_cli.py
 ```
 
-The CLI will display the user list, ask you to pick a user, then start the conversation.
+The CLI displays the user list, asks you to pick a user, then starts the conversation.
+**Phoenix observability launches automatically** with the agent (see the *Observability*
+section below) — there is no separate Phoenix step.
 
 ---
 
 ## Startup order matters
 
 ```
-PostgreSQL  →  MCP Toolbox  →  A2A Servers  →  (Phoenix)  →  Agent
+PostgreSQL  →  MCP Toolbox  →  A2A Servers  →  Agent (auto-launches Phoenix)
 ```
+
+`run.sh` enforces this for you; if you start things manually and the Toolbox or A2A servers
+aren't up, the agent refuses to start.
 
 ---
 
 ## Test users & passwords
 
+Every user's password is their first name, lowercase.
+
 | Email | Password | Tier |
 |:------|:---------|:-----|
-| alice.jones@example.com | alice | Standard |
-| bob.smith@techmail.com | bob | Standard |
-| hannah.m@school.edu | hannah | Premium |
-| julia.child@kitchen.com | julia | Premium |
+| hannah.m@school.edu | `hannah` | Premium |
+| julia.child@kitchen.com | `julia` | Premium |
+| charlie.d@webmail.com | `charlie` | Premium |
+| evan.g@bizcorp.com | `evan` | Premium |
+| alice.jones@example.com | `alice` | Standard |
+| bob.smith@techmail.com | `bob` | Standard |
+| ian.malcolm@chaos.com | `ian` | Standard |
+| diana.prince@hero.net | `diana` | Standard |
+| george.j@jungle.com | `george` | Standard |
+| fiona.shrek@swamp.com | `fiona` | Standard |
 
 ---
 
-## Sample queries to try
+## Using the agent (CLI walkthrough)
+
+1. Start the stack (`./run.sh`). The CLI prints the user table and the welcome banner.
+2. At **`Enter your email:`** type a user's email (e.g. `alice.jones@example.com`).
+3. At **`Enter your password:`** type their password (e.g. `alice`). Input is hidden.
+4. You'll see a 4-step loader (auth → memory → orders → actions), then the `You:` prompt.
+5. Chat. Each turn runs the full pipeline: **sanitize → A2A Security Judge → agent (+ MCP
+   tools, Mem0 memory) → A2A Data Masker** on the response. Type `quit`, `exit`, or `q` to end
+   (your conversation is saved to memory on exit).
+
+**Sample queries**
 
 ```
-What's the status of my latest order?
-Show me all my orders
-Cancel order 3
-I want to return order 1
+What's the status of order 3?           # → MCP get-order-status
+Show me all my orders                    # → MCP find-customer-orders
+I prefer email contact only, remember    # → saved to Mem0 memory
+Cancel order 4                           # → agent confirms, then logs via action-log
+'; DROP TABLE users; --                  # → blocked by the A2A Security Judge
 ```
+
+**Inspect the database** (passwords, orders, and the agent's logged actions) in another shell:
+
+```bash
+conda activate customer-support
+psql -h 127.0.0.1 -p 5432 -d toolbox_db -U toolbox_user   # password: mysecretpassword
+
+# then, inside psql:
+\dt                              -- list tables
+SELECT * FROM users;             -- emails + passwords + tier
+SELECT * FROM customer_orders;   -- orders the agent reads
+SELECT * FROM actions_log;       -- intents the agent logs (cancel/return/address changes)
+```
+
+---
+
+## Observability — Arize Phoenix
+
+The agent ships with **Arize Phoenix** tracing, wired up in
+[`cs_agent/telemetry.py`](cs_agent/telemetry.py). Phoenix is an open-source LLM-observability
+tool: it records a **trace** for every request — a tree of timed **spans** — so you can see
+exactly what the agent did, not just what it said.
+
+**How to run it:** nothing extra. `init_telemetry()` calls `phoenix.launch_app()` when the
+agent starts, so Phoenix is served at **http://localhost:6006** for as long as the CLI is
+running. Open that URL in a browser while you chat and the traces stream in live. (Phoenix runs
+in-process, so it stops when you exit the CLI; the README's old standalone-Phoenix step is no
+longer needed.)
+
+**What you'll see per turn:**
+
+| Span kind | What it captures |
+|:----------|:-----------------|
+| `GUARDRAIL` | input sanitization, the A2A Security Judge verdict, and PII masking |
+| `CHAIN` | the overall agent turn (input → masked output) |
+| `TOOL` | each MCP tool call (`get-order-status`, `find-customer-orders`, `action-log`) with its args and result |
+| LLM spans | every Gemini call — prompt/output, token counts, and per-turn cost |
+
+This makes the multi-agent flow visible: you can watch the Judge clear (or block) a message,
+the MCP tools fire, and the Masker scrub the output, all on one timeline.
+
+> **Setup note:** Phoenix and the OpenTelemetry exporters are installed by `./run.sh setup`
+> (they're not in `requirements.txt`). If you set things up manually, install
+> `arize-phoenix`, `openinference-instrumentation-google-genai`,
+> `openinference-semantic-conventions`, and pin `opentelemetry-sdk==1.42.1` /
+> `opentelemetry-exporter-otlp-proto-http==1.42.1` to match `google-adk`.
 
 ---
 
@@ -237,8 +324,10 @@ I want to return order 1
 │   ├── a2a/                  # A2A microservice infrastructure
 │   ├── agents/               # Judge + Mask ADK agents
 │   └── security/             # Regex blocker + sanitizer
-├── mcp_toolbox/
-│   └── tools.yaml            # DB tool definitions (Postgres)
+├── mcp_toolbox/              # (gitignored) generated by run.sh
+│   ├── tools.yaml            # DB tool definitions (Postgres)
+│   └── seed.sql              # demo data
+├── run.sh                    # one-command orchestrator (setup/start/stop/status/seed/logs)
 ├── .env                      # Your keys (not committed)
 ├── .env.example              # Template
 └── requirements.txt

--- a/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/handoff.md
+++ b/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/handoff.md
@@ -1,0 +1,99 @@
+# Handoff — Module 5 Customer-Support Capstone
+
+**Date:** 2026-06-26
+**Scope:** Getting the Module 5 multi-agent capstone (MCP + A2A + ADK) runnable end-to-end,
+documented, and demoable for a live class.
+
+---
+
+## Current state — it works
+
+The full stack runs **live** on this machine and was verified end-to-end (real Gemini calls,
+real mem0 memory, MCP tools hitting a seeded Postgres, both A2A security servers, Phoenix
+tracing). A scripted CLI session successfully: logged in as Alice, looked up order 3
+(`get-order-status`), listed all orders (`find-customer-orders`), saved a contact preference
+(Mem0), and confirmed a cancel intent (`action-log`). Output came back lowercased — the A2A
+Data Masker processing the response.
+
+Conda env: **`customer-support`** (Python 3.12.13). All deps installed.
+
+---
+
+## What was built this session
+
+- **`run.sh`** — one-command orchestrator (`setup | start | stop | status | seed | logs`).
+  Self-contained: regenerates the gitignored `mcp_toolbox/tools.yaml` + `seed.sql` from
+  embedded heredocs. Committed in **PR #45** (merged to `main`, commit `27ede2b`).
+- **Study-material set** for the module (`study-material/lesson.md`, `key-concepts.md`,
+  `exercises.md`, `quiz.md`, `recap-and-preview.md`). Committed in **PR #44** (merged).
+- **README + `run.sh` updates** (this session, see *Uncommitted* below).
+- **`handoff.md`** — this file.
+
+See the diffs/commits for content; not duplicated here.
+
+---
+
+## Key facts the next agent needs
+
+- **Two API keys** live in the **project** `.env` (`advance-…-ADK/.env`), NOT the repo-root
+  `.env`. `agent_cli.py` does `load_dotenv()` from `cs_agent/` and picks up the project one.
+  Both `GOOGLE_API_KEY` (39 chars, valid) and `MEM0_API_KEY` (43-char `m0-…`, valid) are set.
+- **`.env` footgun (root cause of a long detour):** dotenv treats `KEY=value # comment` as part
+  of the value. The old template had inline `# app.mem0.ai` comments, which got read as the key.
+  Fixed in `run.sh` (comments now on their own lines) — see *Uncommitted*.
+- **Phoenix auto-launches** in-process via `telemetry.py:init_telemetry()` →
+  `px.launch_app()`. It serves at **http://localhost:6006** only while the CLI is alive. The
+  README's old "Terminal 3" standalone Phoenix step is obsolete.
+- **OpenTelemetry pin:** must be **1.42.1** (not the README's old 1.33.1) to satisfy the
+  installed `google-adk 2.3.0` (`>=1.39,<=1.42.1`). Already corrected in `run.sh` and README §3.
+- **Toolbox flag** is `--config` (not the README's old `--tools-file`); pkg
+  `@toolbox-sdk/server@1.5.0`.
+- **macOS:** no `setsid` — `run.sh` uses PID + `pkill -P` + `lsof`-by-port cleanup.
+- **User passwords** = first name lowercase (alice/bob/hannah/julia/…). DB creds:
+  `toolbox_db` / `toolbox_user` / `mysecretpassword` @ `127.0.0.1:5432` (hardcoded in
+  `cs_agent/greet.py` and `mcp_toolbox/tools.yaml`).
+- **`mcp_toolbox/` and `.env` are gitignored** — that's why `tools.yaml` was never committed
+  and had to be reconstructed. `run.sh` regenerates both, so only `run.sh` needs committing.
+- **DLP masking** degrades to a no-op without `GOOGLE_CLOUD_PROJECT` (see
+  `security/masker.py`) — fine for local/class demo.
+
+---
+
+## Uncommitted changes (need a commit/PR)
+
+In the working tree on `main`:
+- `run.sh` — `.env` template fixed (inline-comment footgun removed).
+- `README.md` — added: `./run.sh` quick-start (Option A), fixed manual commands (Option B),
+  full 10-user credential table, "Using the agent (CLI walkthrough)", "Observability — Arize
+  Phoenix" section, corrected OTel pin in §3, `run.sh`/`seed.sql` in project structure.
+- `handoff.md` — this file.
+
+**Next step:** branch, commit these, open a PR, merge (the established workflow this repo uses —
+see PRs #44/#45). The user has been directing each push/merge explicitly.
+
+---
+
+## How to run (for the demo)
+
+```bash
+cd modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK
+./run.sh                       # starts everything, drops into the CLI
+# open http://localhost:6006 in a browser for live Phoenix traces
+```
+Demo queries and DB-inspection commands are in the README's *Using the agent* section.
+
+Background services from this session (Toolbox :5000, A2A :10002/:10003, Postgres :5432) may
+still be running; `./run.sh` auto-clears stale ones before starting.
+
+---
+
+## Open / possible follow-ups
+
+- Commit the uncommitted changes above (primary).
+- Optional: `.env.example` still has `GOOGLE_GENAI_USE_VERTEXAI=1`, which contradicts the
+  AI-Studio-key path — worth aligning with the generated `.env`.
+- Optional: the module README one level up references study-material; verify cross-links.
+
+## Suggested skills for the next session
+- **`review`** or **`verify-work`** before committing the README/`run.sh` changes.
+- The repo's own teaching skills (`teach-module`, `quiz-me`) now have Module 5 content to use.

--- a/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/run.sh
+++ b/modules/Module_5_Multi_Agents/advance-customer-support-agent-feature-A2A-MCP-ADK/run.sh
@@ -345,9 +345,12 @@ cmd_setup() {
 # Use Google AI Studio API key (NOT Vertex). Leave GOOGLE_GENAI_USE_VERTEXAI unset.
 PYTHONWARNINGS=ignore
 
-# REQUIRED — fill these in:
-GOOGLE_API_KEY=        # aistudio.google.com/apikey
-MEM0_API_KEY=          # app.mem0.ai
+# REQUIRED — fill these in. Do NOT put a "# comment" after the value on the same line:
+# dotenv treats it as part of the key. Keep notes on their own line, like these.
+# GOOGLE_API_KEY: get it from https://aistudio.google.com/apikey
+GOOGLE_API_KEY=
+# MEM0_API_KEY: get it from https://app.mem0.ai  (looks like m0-...)
+MEM0_API_KEY=
 
 # Optional (PII masking via Google Cloud DLP, input scan via Model Armor).
 # Leave blank to run fully local — masking degrades to a no-op.


### PR DESCRIPTION
## What

Follow-up to PR #45 (the `run.sh` orchestrator), based on a live end-to-end demo run.

### Fixes
- **`.env` template footgun** in `run.sh`: it put `# comment` on the same line as the key, and `dotenv` reads that as part of the value — which silently truncated `MEM0_API_KEY` to the comment text. Comments now sit on their own lines.

### Docs (project README)
- **Run section** now leads with `./run.sh` (Option A); the manual 4-terminal flow (Option B) is corrected — `--config` (not `--tools-file`), explicit host/port, and the obsolete standalone-Phoenix step removed.
- **Full 10-user credential table** (passwords = first name lowercase).
- **"Using the agent (CLI walkthrough)"** — login steps, sample queries (incl. an injection that the A2A Judge blocks), and `psql` commands to inspect orders + `actions_log`.
- **"Observability — Arize Phoenix"** — what it is, that it auto-launches at http://localhost:6006 with the agent, and a per-turn span table (GUARDRAIL / CHAIN / TOOL / LLM).
- §3 OpenTelemetry pin corrected to `1.42.1` (matches `google-adk 2.3.0`).

### Handoff
- `handoff.md` capturing run state, the key gotchas (env location, OTel pin, Phoenix auto-launch, gitignored `mcp_toolbox/`), and remaining follow-ups.

Verified live: Gemini + Mem0 + MCP/Postgres + A2A Judge/Mask + Phoenix all firing in one CLI session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)