### PR TITLE
Fix: Live Translate widget resolves backend URL lazily (config race)

### DIFF
--- a/FDE/Assignment_1_Live_Translate/widget/translation-widget.js
+++ b/FDE/Assignment_1_Live_Translate/widget/translation-widget.js
@@ -35,6 +35,16 @@
     window.FDE_CONFIG || {}
   );
 
+  // Resolve the backend URL LATE — at call time, not once at load. When the
+  // widget is injected as a content script, window.FDE_CONFIG can be populated
+  // asynchronously (e.g. after the extension reads chrome.storage), which races
+  // this module's synchronous load. Snapshotting API_URL above would lose that
+  // race and get stuck on the default; reading it per use means the current
+  // value always wins, no matter how the widget was loaded.
+  function apiUrl() {
+    return (window.FDE_CONFIG && window.FDE_CONFIG.API_URL) || CONFIG.API_URL;
+  }
+
   // ---- state --------------------------------------------------------------
   let panelOpen = false;
   let busy = false;
@@ -153,7 +163,7 @@
       <div class="fde-badges" id="fde-badges"></div>
       <button class="fde-btn primary" id="fde-page" type="button">Translate page</button>
       <button class="fde-btn ghost" id="fde-restore" type="button">Restore page</button>
-      <div class="fde-status" id="fde-status">Backend: ${CONFIG.API_URL}</div>
+      <div class="fde-status" id="fde-status"></div>
     </div>`;
 
   document.body.appendChild(fab);
@@ -162,6 +172,10 @@
   const badges = panel.querySelector("#fde-badges");
   const statusEl = panel.querySelector("#fde-status");
   const pageBtn = panel.querySelector("#fde-page");
+
+  // Idle hint shows the resolved backend; refreshed each time the panel opens
+  // so a late-arriving FDE_CONFIG is reflected (see apiUrl()).
+  setStatus(backendHint());
 
   // ---- events -------------------------------------------------------------
   fab.addEventListener("click", togglePanel);
@@ -181,6 +195,7 @@
   function setPanel(open) {
     panelOpen = open;
     panel.classList.toggle("open", open);
+    if (open) refreshBackendHint();
   }
 
   async function translatePage() {
@@ -234,7 +249,7 @@
 
   // ---- backend I/O --------------------------------------------------------
   async function postJSON(path, body) {
-    const res = await fetch(CONFIG.API_URL + path, {
+    const res = await fetch(apiUrl() + path, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -275,13 +290,20 @@
     statusEl.textContent = text;
     statusEl.classList.toggle("err", !!isErr);
   }
+  function backendHint() {
+    return "Backend: " + apiUrl();
+  }
+  function refreshBackendHint() {
+    // refresh only the idle hint — never clobber progress, results, or errors
+    if (statusEl.textContent.startsWith("Backend:")) setStatus(backendHint());
+  }
   function handleError(err) {
     if (err instanceof NotImplemented) {
       setStatus(`${err.path} isn't implemented yet — build it in your backend!`, true);
     } else if (err.message && err.message.startsWith("HTTP")) {
       setStatus(`Backend error (${err.message}). Check your gateway/AI-service logs.`, true);
     } else {
-      setStatus(`Can't reach backend at ${CONFIG.API_URL}. Is your Node gateway running?`, true);
+      setStatus(`Can't reach backend at ${apiUrl()}. Is your Node gateway running?`, true);
     }
     console.error("[FDE]", err);
   }
@@ -298,5 +320,5 @@
   NotImplemented.prototype = Object.create(Error.prototype);
 
   console.log("%c[FDE] Live Translate widget loaded.", "color:#10b981;font-weight:bold");
-  console.log("[FDE] Backend:", CONFIG.API_URL, "· open the button bottom-right.");
+  console.log("[FDE] Backend:", apiUrl(), "· open the button bottom-right.");
 })();


### PR DESCRIPTION
## Summary
The Live Translate widget ignores a custom **Backend URL** set in the extension
popup — it always calls the default `http://localhost:8787`, so it can't reach a
deployed gateway (e.g. a Fly.io URL). Surfaces only after deploying, when you
point the extension at a non-localhost backend.

## Root cause — config race
`extension/content.js` and `widget/translation-widget.js` are one content-scripts
entry at `document_idle`, so they run back-to-back synchronously. `content.js`
reads the saved URL via `chrome.storage.sync.get(...)` (async) and sets
`window.FDE_CONFIG` in its callback — but the widget runs synchronously right
after and snapshots `API_URL` into `CONFIG` **before** that callback fires,
falling back to the hard-coded default. Confirmed the ordering even with a
microtask (faster than a real storage IPC): the sync read always wins.

It's latent because the widget's default equals the local gateway, so the whole
local workflow works regardless — only the override path (post-deploy) breaks.

## Fix
Resolve the backend URL **at call time** via an `apiUrl()` accessor instead of
caching it once at load. The current value now wins no matter how the widget is
loaded (console loader, extension, or direct `<script>`). The panel's "Backend:"
hint is refreshed when the panel opens so a late-arriving config is reflected.

Scope: `widget/translation-widget.js` only. No behavior change on the default
(localhost) path.

## Verification
- `node --check` passes.
- Simulation: with config arriving *after* load, `apiUrl()` returns the new URL
  (old code stayed on `localhost`).
- Unchanged on all three documented load paths.
