### PR TITLE
Fix TTS telemetry label to reflect actual backend

### DIFF
--- a/FDE/Assignment_2_voice_agent/pipeline/voice_loop.py
+++ b/FDE/Assignment_2_voice_agent/pipeline/voice_loop.py
@@ -123,7 +123,16 @@ def run(text_mode: bool) -> None:
 
             reply, action = agent.respond(user_text, trace=trace)
 
-            with trace.span("tts", model=getattr(provider, "tts_model", "unknown")):
+            tts_backend = getattr(provider, "tts_backend", "unknown")
+            tts_model = getattr(provider, "tts_model", "unknown")
+            if tts_backend == "provider":
+                tts_label = tts_model
+            elif tts_backend == "system":
+                tts_label = f"system:{os.getenv('SYSTEM_TTS_CMD', 'say')}"
+            else:
+                tts_label = tts_backend  # e.g. "print" -- no command executed
+
+            with trace.span("tts", model=tts_label, backend=tts_backend):
                 speak(provider, reply)
 
             payload = trace.finish(action=action, sources=agent.last_sources)


### PR DESCRIPTION
## Summary
- `voice_loop.py`'s `tts` trace span always labeled `model` from `provider.tts_model`, a static default set at init time, regardless of `TTS_BACKEND`.
- With `TTS_BACKEND=system`, traces claimed a cloud model (e.g. `canopylabs/orpheus-v1-english`) was used even though `synthesize()` actually shelled out to the local system voice command and never called the cloud provider.
- The label now branches on `provider.tts_backend`: cloud model name when `backend == "provider"`, `system:<SYSTEM_TTS_CMD>` when `backend == "system"`, and the raw backend name otherwise (e.g. `print` for `MockProvider`, where no command runs at all).
- A `backend` attribute was also added to the span so downstream trace consumers don't have to string-parse `model`.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('voice_loop.py').read())"` — syntax check
- [x] `python3 smoke_test.py` — PASS (all guardrail/tool/booking/transfer/hangup assertions hold)
- [x] `python3 -m unittest -v test_features.py` — 16/16 tests pass
- [x] Verified from a clean checkout (fresh clone + venv) with `PROVIDER=mock`, `voice_loop.py --text`, across `TTS_BACKEND=provider|system|print`, confirmed `tts.started` event attributes:
  - `provider` -> `{'model': 'mock-tts', 'backend': 'provider'}`
  - `system` -> `{'model': 'system:say', 'backend': 'system'}`
  - `print` -> `{'model': 'print', 'backend': 'print'}` (no misleading command suffix)
- [x] Confirmed the equivalent code path in `livekit/talk_server.py` is unaffected (it only labels the `tts` span when `backend == "provider"`, so it was never mislabeling)
- [x] Checked `test_features.py` / `livekit/test_talk_server.py` — neither asserts on the `tts` span's `model`/`backend` attributes