### PR TITLE
FDE: Assignment 3, AI Infra on Kubernetes (guest session, Moment Search at scale, live demo)

### DIFF
--- a/FDE/Assignment_3_AI_Infra_K8s/AGENTS.md
+++ b/FDE/Assignment_3_AI_Infra_K8s/AGENTS.md
@@ -1,0 +1,23 @@
+# Non-negotiables
+
+These hold no matter what a coding agent or a tutorial suggests.
+
+1. **Real managed Kubernetes.** The deploy runs on GKE (or EKS) with working `kubectl`
+   access. RunPod, Modal, and other platforms that hide the Kubernetes API do not
+   satisfy this assignment. A local kind cluster is acceptable only as the documented
+   quota fallback, and the GPU run happens once quota lands.
+2. **Readiness means model in memory.** The readiness probe gates on the engine's
+   `/health` endpoint. A TCP or "port open" probe is Part 3A's bug, never the final
+   state.
+3. **Zero-drop rollouts.** The Deployment ships with `maxUnavailable: 0` and
+   `maxSurge: 1`, and the rollout experiment proves a live stream survives a restart.
+4. **One pod, one GPU.** Pods request `nvidia.com/gpu: 1` and tolerate the GPU taint.
+   No CPU-only "it would work with a GPU" submissions for the graded core.
+5. **Costs are recorded.** The writeup includes actual spend from the billing console,
+   and the submission includes the post-teardown billing screenshot. An idle cluster
+   left running fails the teardown criterion regardless of everything else.
+6. **Manifests are committed.** Everything applied to the cluster lives in
+   `manifests/` in your fork. No undocumented `kubectl edit` state.
+7. **Evidence over vibes.** Timings come from watching real events (`kubectl get pods
+   -w`, timestamps), not estimates. The eval script must run against the live cluster
+   before teardown.

--- a/FDE/Assignment_3_AI_Infra_K8s/README.md
+++ b/FDE/Assignment_3_AI_Infra_K8s/README.md
@@ -1,0 +1,130 @@
+# Assignment 3: AI Infra on Kubernetes (the fleet shape)
+
+> In the earlier labs you rented one GPU and served a model with vLLM. This assignment is
+> what a Forward Deployed Engineer does after that demo: stand up a real Kubernetes
+> cluster, deploy that same engine as a fleet, and then break and fix the three
+> production assumptions that separate a demo from a deploy.
+
+Companion session: **AI training, tuning, inference and RL on Kubernetes** (July 23,
+2026). The recap lives in [`SESSION_NOTES.md`](SESSION_NOTES.md); this assignment is
+the "inference fleet" section of that session, enacted on a cluster you own.
+
+Budget about 3 hours and under $10 of cloud spend. The $300 GCP free credit covers it
+many times over. **Teardown is graded.**
+
+## Why GKE and not RunPod, Latitude, or Modal
+
+The learning objective is Kubernetes, not GPU access.
+
+- **GKE** gives you real `kubectl`, node pools, taints, probes, rollouts and an
+  autoscaler, and it installs NVIDIA drivers for you. This is what enterprise customers
+  actually run.
+- **RunPod / Latitude.sh** were perfect for the one-box vLLM lab. RunPod never hands you
+  a Kubernetes API; Latitude gives you bare metal where you would install k3s and the
+  GPU stack yourself before the lesson starts.
+- **Modal** is a great product whose whole pitch is hiding Kubernetes from you. Using it
+  here teaches the opposite lesson.
+
+Already have AWS credits? EKS with a g5/g6 node group works; the manifests are
+identical, the cluster setup is on you.
+
+## Part 0: Accounts and quota (start early, this has a wait)
+
+1. Install `gcloud`, create a project, enable the Kubernetes Engine API.
+2. Upgrade the account from free trial to paid billing. Your $300 credit survives; GPU
+   quota does not exist on trial accounts.
+3. Request quota: IAM & Admin, Quotas, filter "NVIDIA L4 GPUs" (or T4), region
+   `us-central1`, request 1 or 2. Approval usually takes minutes to hours.
+4. This step is part of the assignment. Quota tickets are real FDE work; record how long
+   yours took.
+
+## Part 1: Create the cluster (about 10 minutes)
+
+```bash
+gcloud container clusters create fde-lab \
+  --zone us-central1-a --num-nodes 1 --machine-type e2-standard-4
+
+gcloud container node-pools create gpu-pool \
+  --cluster fde-lab --zone us-central1-a \
+  --machine-type g2-standard-8 \
+  --accelerator type=nvidia-l4,count=1,gpu-driver-version=latest \
+  --num-nodes 2 --spot
+```
+
+T4 variant if L4 quota is slow: `--machine-type n1-standard-4 --accelerator
+type=nvidia-tesla-t4,count=1,gpu-driver-version=latest`.
+
+Check the five words from the session: `kubectl get nodes` shows your node pools;
+`kubectl describe node <gpu-node>` shows `nvidia.com/gpu: 1` and the taint that keeps
+ordinary pods off expensive hardware.
+
+## Part 2: Deploy the fleet
+
+Apply the provided scaffolding and watch it come up:
+
+```bash
+kubectl apply -f manifests/vllm.yaml
+kubectl get pods -w
+```
+
+Read [`manifests/vllm.yaml`](manifests/vllm.yaml) top to bottom before applying it.
+Every field exists for a reason covered in the session: one pod per GPU, a readiness
+probe that gates on `/health` (model in memory, not port open), a rollout strategy that
+never drops below full capacity, and a toleration for the GPU taint.
+
+Record the gap between `Running` and `Ready`. That gap is the model loading into VRAM.
+Then curl the LoadBalancer IP with an OpenAI-style chat request until tokens stream
+back.
+
+## Part 3: Break it three ways (the graded core)
+
+**A. The lying probe.** Change the readiness probe to a plain TCP check on port 8000 and
+redeploy. Curl the service repeatedly during startup and capture the failures that now
+leak through. Revert. One paragraph: why did "port open" lie?
+
+**B. Capacity is bought, not borrowed.** `kubectl scale deployment vllm --replicas=3`.
+The pod goes `Pending`; the cluster buys a Spot node, installs drivers, pulls the image,
+loads weights. Time the whole chain from scale command to `Ready`. That number is why
+fleets keep a warm floor.
+
+**C. The rollout that drops nobody.** With `maxUnavailable: 0, maxSurge: 1` in place
+(already set in the scaffolding), start a long streaming completion in one terminal and
+run `kubectl rollout restart deployment vllm` in another. Confirm the stream finishes.
+Explain what would have happened without those two settings.
+
+## Part 4: Stretch goals (pick one)
+
+- **Tensor parallel:** recreate the GPU pool with `g2-standard-24` and `count=2`, serve
+  a 7B class model with `--tensor-parallel-size 2`.
+- **The queue shape:** install Kueue, set a quota of 1 GPU, submit three fine-tune style
+  Jobs, watch them admit one at a time.
+- **Smart traffic:** install the Gateway API Inference Extension and route by model
+  name.
+
+## Deliverables
+
+1. Run the eval: `python eval/eval.py` against your live cluster. It writes
+   `eval/REPORT.md`.
+2. A one-page writeup: your three timings (Ready gap, scale-up chain, rollout), total
+   spend from the billing page, and the one thing that surprised you.
+3. A 60 to 90 second screen recording: `kubectl get pods -w` during the scale-up, and a
+   streamed completion answered from the LoadBalancer IP.
+4. A screenshot of the empty billing page after teardown.
+
+The rubric is in [`eval/rubric.json`](eval/rubric.json). Non-negotiables are in
+[`AGENTS.md`](AGENTS.md).
+
+## Teardown (graded, not optional)
+
+```bash
+gcloud container clusters delete fde-lab --zone us-central1-a
+```
+
+GPUs bill while idle. Delete the cluster the same day. Leaving a GPU node running
+overnight is also an FDE lesson, just an expensive one.
+
+## If quota is stuck
+
+Do every Kubernetes step on a local kind cluster with a CPU model (ollama or vLLM CPU
+mode with a 0.5B model). The mechanics of probes, scaling and rollouts are identical.
+Swap in the GPU pool when the quota lands, then rerun the eval.

--- a/FDE/Assignment_3_AI_Infra_K8s/README.md
+++ b/FDE/Assignment_3_AI_Infra_K8s/README.md
@@ -1,10 +1,10 @@
 # Assignment 3: AI Infra on Kubernetes (RAG at scale for Moment Search)
 
-> In the earlier labs you rented one GPU and served a model with vLLM. This assignment is
-> what a Forward Deployed Engineer does after that demo: take a working AI application,
-> replace its hosted LLM with an open-source model you serve yourself, and then run that
-> model as a real fleet on Kubernetes, with the break-and-fix experiments that separate
-> a demo from a deploy.
+> So far you have used LLMs the way most of the world does: through a hosted
+> OpenAI-style API. This assignment is where you cross to the other side of that URL.
+> You will serve an open-source model yourself with vLLM for the first time, wire a
+> working AI application to it, and then run it as a real fleet on Kubernetes, with the
+> break-and-fix experiments that separate a demo from a deploy.
 
 The application is **[Moment Search](https://github.com/traversaal-ai/momentsearch)**:
 visual video search and RAG (CLIP retrieval + Qdrant + bring-your-own vision LLM). You
@@ -23,9 +23,9 @@ $10; the $300 GCP free credit covers it many times over. **Teardown is graded.**
 
 ## The two rungs
 
-- **Rung A (warm-up): one box on RunPod.** The same move you made in the vLLM lab, now
-  serving a vision model that a real application depends on. RunPod is perfect here and
-  requires no quota wait.
+- **Rung A (warm-up): one box on RunPod.** Your first time serving a model yourself:
+  one rented GPU, one command, and a vision model that a real application depends on.
+  RunPod is perfect here and requires no quota wait.
 - **Rung B (graded core): the fleet on GKE.** The learning objective of this rung is
   Kubernetes itself: kubectl, node pools, probes, rollouts, autoscaling and cost
   hygiene, on the platform enterprise customers actually run. RunPod and Modal are
@@ -60,8 +60,9 @@ piece is what you are about to own.
 
 ## Part 2, Rung A: one box on RunPod (warm-up)
 
-Rent a single 24 GB+ GPU on RunPod and serve the vision model with vLLM, the same way
-you did in the earlier lab:
+Rent a single 24 GB+ GPU on RunPod and serve the vision model with vLLM. One command
+turns a rented GPU into the same OpenAI-compatible endpoint you have been calling all
+course, except now you own it:
 
 ```bash
 vllm serve Qwen/Qwen2.5-VL-7B-Instruct --max-model-len 8192 --limit-mm-per-prompt image=8

--- a/FDE/Assignment_3_AI_Infra_K8s/README.md
+++ b/FDE/Assignment_3_AI_Infra_K8s/README.md
@@ -1,44 +1,86 @@
-# Assignment 3: AI Infra on Kubernetes (the fleet shape)
+# Assignment 3: AI Infra on Kubernetes (RAG at scale for Moment Search)
 
 > In the earlier labs you rented one GPU and served a model with vLLM. This assignment is
-> what a Forward Deployed Engineer does after that demo: stand up a real Kubernetes
-> cluster, deploy that same engine as a fleet, and then break and fix the three
-> production assumptions that separate a demo from a deploy.
+> what a Forward Deployed Engineer does after that demo: take a working AI application,
+> replace its hosted LLM with an open-source model you serve yourself, and then run that
+> model as a real fleet on Kubernetes, with the break-and-fix experiments that separate
+> a demo from a deploy.
+
+The application is **[Moment Search](https://github.com/traversaal-ai/momentsearch)**:
+visual video search and RAG (CLIP retrieval + Qdrant + bring-your-own vision LLM). You
+will not modify its code. You will change three lines of its `.env`, which is the whole
+point: vLLM speaks the OpenAI API, so owning your model is a config change, not a
+rewrite.
 
 Companion session: **AI training, tuning, inference and RL on Kubernetes** (July 23,
-2026). The recap lives in [`SESSION_NOTES.md`](SESSION_NOTES.md); this assignment is
-the "inference fleet" section of that session, enacted on a cluster you own.
+2026). Recap in [`SESSION_NOTES.md`](SESSION_NOTES.md). The instructor demo runbook for
+this exact stack is in [`demo/`](demo/).
 
-Budget about 3 hours and under $10 of cloud spend. The $300 GCP free credit covers it
-many times over. **Teardown is graded.**
+One catch that matters: Moment Search shows the LLM actual video frames, so your model
+must be **vision-capable**. Text-only models will not work. We use
+`Qwen/Qwen2.5-VL-7B-Instruct` (Apache 2.0, fits one L4). Budget about 3 hours and under
+$10; the $300 GCP free credit covers it many times over. **Teardown is graded.**
 
-## Why GKE and not RunPod, Latitude, or Modal
+## The two rungs
 
-The learning objective is Kubernetes, not GPU access.
+- **Rung A (warm-up): one box on RunPod.** The same move you made in the vLLM lab, now
+  serving a vision model that a real application depends on. RunPod is perfect here and
+  requires no quota wait.
+- **Rung B (graded core): the fleet on GKE.** The learning objective of this rung is
+  Kubernetes itself: kubectl, node pools, probes, rollouts, autoscaling and cost
+  hygiene, on the platform enterprise customers actually run. RunPod and Modal are
+  great products that hide the Kubernetes API; that is exactly why they cannot carry
+  this rung.
 
-- **GKE** gives you real `kubectl`, node pools, taints, probes, rollouts and an
-  autoscaler, and it installs NVIDIA drivers for you. This is what enterprise customers
-  actually run.
-- **RunPod / Latitude.sh** were perfect for the one-box vLLM lab. RunPod never hands you
-  a Kubernetes API; Latitude gives you bare metal where you would install k3s and the
-  GPU stack yourself before the lesson starts.
-- **Modal** is a great product whose whole pitch is hiding Kubernetes from you. Using it
-  here teaches the opposite lesson.
-
-Already have AWS credits? EKS with a g5/g6 node group works; the manifests are
-identical, the cluster setup is on you.
+Already have AWS credits? EKS with a g5/g6 node group works; manifests are identical.
 
 ## Part 0: Accounts and quota (start early, this has a wait)
 
 1. Install `gcloud`, create a project, enable the Kubernetes Engine API.
-2. Upgrade the account from free trial to paid billing. Your $300 credit survives; GPU
-   quota does not exist on trial accounts.
-3. Request quota: IAM & Admin, Quotas, filter "NVIDIA L4 GPUs" (or T4), region
-   `us-central1`, request 1 or 2. Approval usually takes minutes to hours.
-4. This step is part of the assignment. Quota tickets are real FDE work; record how long
-   yours took.
+2. Upgrade from free trial to paid billing. The $300 credit survives; GPU quota does
+   not exist on trial accounts.
+3. Request quota: IAM & Admin, Quotas, "NVIDIA L4 GPUs", region `us-central1`, request
+   2. Approval usually takes minutes to hours.
+4. This step is part of the assignment. Quota tickets are real FDE work; record how
+   long yours took.
 
-## Part 1: Create the cluster (about 10 minutes)
+## Part 1: Meet the app (15 minutes, no GPU needed)
+
+```bash
+git clone https://github.com/traversaal-ai/momentsearch.git
+cd momentsearch
+cp .env.example .env
+docker compose up --build
+python examples/quickstart.py     # seeds the sample corpus
+```
+
+Open http://localhost:8000. Retrieval works with no LLM key at all (CLIP runs
+locally). Ask a question and note what is missing: the cited answer. That missing
+piece is what you are about to own.
+
+## Part 2, Rung A: one box on RunPod (warm-up)
+
+Rent a single 24 GB+ GPU on RunPod and serve the vision model with vLLM, the same way
+you did in the earlier lab:
+
+```bash
+vllm serve Qwen/Qwen2.5-VL-7B-Instruct --max-model-len 8192 --limit-mm-per-prompt image=8
+```
+
+Point Moment Search at it in `.env` and restart the app:
+
+```
+LLM_PROVIDER=openai
+LLM_BASE_URL=http://<runpod-ip>:8000/v1
+LLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct
+LLM_API_KEY=not-needed
+```
+
+Ask the same question again. Same app, your model, cited answers. Screenshot it, then
+shut the pod down. That is the whole rung; everything after this is about what happens
+when one box is not enough.
+
+## Part 3, Rung B: create the cluster (about 10 minutes)
 
 ```bash
 gcloud container clusters create fde-lab \
@@ -48,70 +90,82 @@ gcloud container node-pools create gpu-pool \
   --cluster fde-lab --zone us-central1-a \
   --machine-type g2-standard-8 \
   --accelerator type=nvidia-l4,count=1,gpu-driver-version=latest \
-  --num-nodes 2 --spot
+  --num-nodes 2 --enable-autoscaling --min-nodes 1 --max-nodes 3 --spot
 ```
 
-T4 variant if L4 quota is slow: `--machine-type n1-standard-4 --accelerator
-type=nvidia-tesla-t4,count=1,gpu-driver-version=latest`.
+The autoscaling flags matter: experiment B below only works if the cluster is allowed
+to buy a third node. Check the five words from the session: `kubectl get nodes` shows
+your node pools; `kubectl describe node <gpu-node>` shows `nvidia.com/gpu: 1` and the
+taint that keeps ordinary pods off expensive hardware.
 
-Check the five words from the session: `kubectl get nodes` shows your node pools;
-`kubectl describe node <gpu-node>` shows `nvidia.com/gpu: 1` and the taint that keeps
-ordinary pods off expensive hardware.
+## Part 4: Deploy the fleet and rewire the app
 
-## Part 2: Deploy the fleet
-
-Apply the provided scaffolding and watch it come up:
+Read [`manifests/vllm.yaml`](manifests/vllm.yaml) top to bottom, then:
 
 ```bash
 kubectl apply -f manifests/vllm.yaml
 kubectl get pods -w
 ```
 
-Read [`manifests/vllm.yaml`](manifests/vllm.yaml) top to bottom before applying it.
 Every field exists for a reason covered in the session: one pod per GPU, a readiness
-probe that gates on `/health` (model in memory, not port open), a rollout strategy that
-never drops below full capacity, and a toleration for the GPU taint.
+probe that gates on `/health` (model in memory, not port open), a rollout strategy
+that never dips below full capacity, and a toleration for the GPU taint. Record the
+gap between `Running` and `Ready`; that gap is the weights loading into VRAM.
 
-Record the gap between `Running` and `Ready`. That gap is the model loading into VRAM.
-Then curl the LoadBalancer IP with an OpenAI-style chat request until tokens stream
-back.
+Get the front door and point the app at the fleet:
 
-## Part 3: Break it three ways (the graded core)
+```bash
+kubectl get svc vllm    # note EXTERNAL-IP
+```
 
-**A. The lying probe.** Change the readiness probe to a plain TCP check on port 8000 and
-redeploy. Curl the service repeatedly during startup and capture the failures that now
+```
+LLM_BASE_URL=http://<EXTERNAL-IP>/v1
+```
+
+Restart Moment Search and ask again. The answer now comes from a two-replica fleet
+behind a LoadBalancer. Nothing in the app changed.
+
+## Part 5: Break it three ways (the graded core)
+
+Run every experiment with the app open. Infrastructure failures are only real when you
+watch them through a product.
+
+**A. The lying probe.** Change the readiness probe to a plain TCP check on port 8000
+and redeploy. Ask questions in the app during startup and capture the failures that
 leak through. Revert. One paragraph: why did "port open" lie?
 
 **B. Capacity is bought, not borrowed.** `kubectl scale deployment vllm --replicas=3`.
-The pod goes `Pending`; the cluster buys a Spot node, installs drivers, pulls the image,
-loads weights. Time the whole chain from scale command to `Ready`. That number is why
-fleets keep a warm floor.
+The pod goes `Pending`; the cluster buys a Spot node, installs drivers, pulls the
+image, loads weights. Time the whole chain from scale command to `Ready`. That number
+is why fleets keep a warm floor.
 
-**C. The rollout that drops nobody.** With `maxUnavailable: 0, maxSurge: 1` in place
-(already set in the scaffolding), start a long streaming completion in one terminal and
-run `kubectl rollout restart deployment vllm` in another. Confirm the stream finishes.
-Explain what would have happened without those two settings.
+**C. The rollout that drops nobody.** With `maxUnavailable: 0, maxSurge: 1` already in
+the scaffolding, ask the app a question and run `kubectl rollout restart deployment
+vllm` while the answer streams. Confirm it finishes. Then delete one pod outright and
+ask again: the readiness gate keeps traffic on the healthy replica while the dead one
+resurrects. Explain both behaviors.
 
-## Part 4: Stretch goals (pick one)
+## Stretch goals (pick one)
 
-- **Tensor parallel:** recreate the GPU pool with `g2-standard-24` and `count=2`, serve
-  a 7B class model with `--tensor-parallel-size 2`.
-- **The queue shape:** install Kueue, set a quota of 1 GPU, submit three fine-tune style
-  Jobs, watch them admit one at a time.
+- **Tensor parallel:** recreate the GPU pool with `g2-standard-24` and `count=2`,
+  serve the model with `--tensor-parallel-size 2`.
+- **The queue shape:** install Kueue, set a quota of 1 GPU, submit three fine-tune
+  style Jobs, watch them admit one at a time.
 - **Smart traffic:** install the Gateway API Inference Extension and route by model
   name.
 
 ## Deliverables
 
-1. Run the eval: `python eval/eval.py` against your live cluster. It writes
+1. Run `python eval/eval.py` against the live cluster before teardown; it writes
    `eval/REPORT.md`.
-2. A one-page writeup: your three timings (Ready gap, scale-up chain, rollout), total
-   spend from the billing page, and the one thing that surprised you.
-3. A 60 to 90 second screen recording: `kubectl get pods -w` during the scale-up, and a
-   streamed completion answered from the LoadBalancer IP.
+2. A one-page writeup: your three timings (Ready gap, scale-up chain, rollout), Rung A
+   vs Rung B observations, actual spend from the billing page, and the one thing that
+   surprised you.
+3. A 60 to 90 second recording: Moment Search answering through your fleet, then
+   `kubectl get pods -w` during the scale-up.
 4. A screenshot of the empty billing page after teardown.
 
-The rubric is in [`eval/rubric.json`](eval/rubric.json). Non-negotiables are in
+Rubric: [`eval/rubric.json`](eval/rubric.json). Non-negotiables:
 [`AGENTS.md`](AGENTS.md).
 
 ## Teardown (graded, not optional)
@@ -125,6 +179,7 @@ overnight is also an FDE lesson, just an expensive one.
 
 ## If quota is stuck
 
-Do every Kubernetes step on a local kind cluster with a CPU model (ollama or vLLM CPU
-mode with a 0.5B model). The mechanics of probes, scaling and rollouts are identical.
-Swap in the GPU pool when the quota lands, then rerun the eval.
+Do Rung A on RunPod (no quota needed), and every Kubernetes step on a local kind
+cluster with a CPU model (ollama with `qwen2.5-vl` or vLLM CPU mode). Probes, scaling
+and rollouts behave identically. Swap in the GPU pool when quota lands, then rerun the
+eval.

--- a/FDE/Assignment_3_AI_Infra_K8s/SESSION_NOTES.md
+++ b/FDE/Assignment_3_AI_Infra_K8s/SESSION_NOTES.md
@@ -1,0 +1,87 @@
+# Session notes: AI training, tuning, inference and RL on Kubernetes
+
+Guest session for the FDE track, July 23, 2026.
+Speaker: **Sanjeev Ganjihal**, AI Infrastructure Engineer, Google.
+[LinkedIn](https://www.linkedin.com/in/sanjeevg89/) · [Substack](https://sanjeevganjihal.substack.com/)
+
+## The one idea
+
+The cluster does not care what a "model" is. It cares what **shape** the work is, and
+shape picks the pattern. Every AI workload you will ever meet is one of four shapes,
+and all four run on the same substrate: Kubernetes.
+
+| Shape | What it is | The Kubernetes pattern |
+|---|---|---|
+| **Training** | one giant machine: thousands of GPUs in lockstep, all or nothing | gang scheduling: JobSet + Kueue + constant checkpoints |
+| **Fine-tuning** | a queue of small short jobs; interruption is fine | Jobs on Spot GPUs + quota queue + checkpoint/resume |
+| **Inference** | an always-on fleet behind a URL that breathes with traffic | Deployment / LeaderWorkerSet + LLM-aware routing and autoscaling |
+| **RL** | a factory loop: an inference fleet feeding a training gang | Ray on Kubernetes gluing both worlds + weight shipping |
+
+## The 5-layer AI infra stack
+
+Every fix has a floor. Diagnose on the right one.
+
+| Layer | Name | Lives here |
+|---|---|---|
+| L5 | Workloads and frameworks | vLLM, SGLang, PyTorch FSDP, JAX, TRL/veRL, LoRA stacks |
+| L4 | **Cloud-native orchestration (the session)** | Kubernetes, Kueue, JobSet, LeaderWorkerSet, KubeRay, Inference Gateway, Karpenter |
+| L3 | Managed cluster and cloud | GKE / EKS / AKS, node pools, VPC and IAM, GPU quotas, Spot |
+| L2 | Storage and network fabric | S3/GCS, NVMe caches, NVLink, InfiniBand/RoCE, GPUDirect |
+| L1 | Accelerators and silicon | NVIDIA H200/Blackwell, Google TPU (Trillium, Ironwood), CPUs for graders |
+
+Routing table: slow tokens go to L5 (engine settings) · pods stuck Pending go to L4
+(queues and quotas) · minutes-long cold starts go to L2/L3 (weight staging) ·
+throughput cliffs on big jobs go to L2 fabric or L1 topology.
+
+## The parallelism toolbox
+
+Four ways to split a model. Each one is a bet about your network.
+
+| Technique | Splits | Stresses | Used by |
+|---|---|---|---|
+| Data parallel (DP/FSDP) | the batch; same model everywhere, average the results | all-reduce bandwidth (InfiniBand/RoCE) | every trainer, RL updates |
+| Tensor parallel (TP) | every layer's matrices; 4-8 GPUs act as one | NVLink inside one node, never across boxes | big-model serving |
+| Pipeline parallel (PP) | the model by depth; layers in a relay | tolerates slower links | giant training runs |
+| Expert parallel (EP) | MoE experts; a router picks a few per token | all-to-all traffic | trillion-scale MoEs (Kimi K3, DeepSeek V4) |
+
+Frontier training stacks all four. Fine-tuning needs none of them; that is LoRA's whole
+trick. Placement that respects the fabric runs up to 2x faster on identical hardware,
+which is why topology-aware scheduling exists.
+
+## The field guide
+
+- **Train, a gang:** JobSet describes the many-pods-one-job gang · Kueue admits it all
+  or nothing against team quotas · checkpoints to object storage make failure cost
+  minutes · topology decides placement.
+- **Fine-tune, a queue:** LoRA/QLoRA shrinks it to one card · a K8s Job runs it to
+  completion · Spot GPUs at 60-90% off because checkpoint/resume tolerates eviction ·
+  Kueue meters the experiment queue.
+- **Serve, a fleet:** vLLM pods in a Deployment, or LeaderWorkerSet when the model spans
+  nodes · readiness = model in memory · route on queue depth and prefix reuse ·
+  autoscale on tokens, never CPU% · drain streams before killing pods.
+- **RL, the loop:** a generation fleet (vLLM) + graders + a training gang, glued by Ray
+  on Kubernetes · weights stream back every round · generation is the bottleneck, so
+  inference skills carry the day.
+
+## Receipts worth knowing (verified July 2026)
+
+- CNCF 2025 survey: 82% of container users run Kubernetes in production; 66% of
+  organizations run some or all AI inference on it.
+- CoreWeave runs a Kubernetes-native GPU cloud (SUNK, Slurm on Kubernetes) with single
+  jobs past 32,000 GPUs; OpenAI trains there under $22B+ in committed deals.
+- Google's GKE supports 65,000-node clusters; Anthropic's published GKE work cut
+  failure recovery from hours to 2-5 minutes.
+- The open frontier went trillion-scale in one month: Kimi K3 (2.8T, open weights),
+  DeepSeek V4 (1.6T, MIT), Qwen3.8-Max (2.4T, preview). Moonshot serves K3 with
+  Mooncake, split prefill/decode pools, reporting a 90% cache-hit rate.
+- Failure at scale is arithmetic, not anecdote: fleet failure interval equals per-part
+  MTBF divided by part count. 100,000 accelerators at a five-year MTBF means a fault
+  roughly every half hour, which is why checkpoints, health checks and topology-aware
+  placement are the three reflexes of every frontier cluster.
+
+## Sources
+
+- [CNCF 2025 annual survey](https://www.cncf.io/announcements/2026/01/20/kubernetes-established-as-the-de-facto-operating-system-for-ai-as-production-use-hits-82-in-2025-cncf-annual-cloud-native-survey/)
+- [CoreWeave SUNK](https://www.coreweave.com/blog/why-sunk-redefines-the-ai-research-cluster-for-production-grade-training) · [CoreWeave and OpenAI](https://www.coreweave.com/news/coreweave-expands-agreement-with-openai-by-up-to-6-5b)
+- [GKE 65,000-node clusters](https://cloud.google.com/blog/products/containers-kubernetes/gke-65k-nodes-and-counting) · [Anthropic on GKE](https://www.zenml.io/llmops-database/scaling-ai-training-and-inference-infrastructure-with-gke-dynamic-slicing-on-tpus)
+- [Kimi K3](https://www.kimi.com/blog/kimi-k3) · [DeepSeek V4](https://api-docs.deepseek.com/news/news260424/) · [Qwen3.8-Max](https://www.marktechpost.com/2026/07/19/alibaba-previews-qwen3-8-max-a-2-4-trillion-parameter-multimodal-model-days-after-moonshots-kimi-k3-open-weight-launch/)

--- a/FDE/Assignment_3_AI_Infra_K8s/demo/README.md
+++ b/FDE/Assignment_3_AI_Infra_K8s/demo/README.md
@@ -1,0 +1,97 @@
+# Live demo runbook: Moment Search on a GKE vLLM fleet
+
+A five minute end-to-end demo for the July 23 session. Moment Search answers questions
+about video, on screen, backed by a self-served open-source vision model running as a
+two-replica vLLM fleet on GKE. Mid-demo we kill a pod while the app keeps answering,
+then scale the fleet and watch the cluster buy a GPU node live.
+
+Everything here is reproducible from scratch by one engineer in about 45 minutes and
+roughly $3 of spend. It is the same stack students build in Assignment 3, so rehearsing
+the demo also validates the assignment.
+
+## What the audience sees
+
+1. A real product (Moment Search sample corpus) answering with cited video moments.
+2. `.env` on screen: three lines are the entire difference between OpenAI and a fleet
+   you own. vLLM speaks the same API.
+3. A pod deleted mid-question; the answer still streams. The fleet shape: any N.
+4. `kubectl scale --replicas=3`; a Pending pod triggers a live Spot node purchase.
+   While it provisions, the speaker explains the warm floor.
+
+## Prerequisites
+
+- gcloud authenticated to a project with billing enabled and quota for 3 L4 GPUs in
+  `us-central1` (request 3, not 2: the scale-out moment needs headroom).
+- kubectl, Docker, Python 3.11, FFmpeg.
+- No API keys needed. Retrieval is local CLIP; generation is the fleet.
+
+## Provision (T minus 60 minutes)
+
+```bash
+./provision.sh    # creates cluster + GPU pool, applies manifests, waits for Ready
+```
+
+The script prints the LoadBalancer IP when the fleet is up. First readiness takes 5 to
+10 minutes (node boot, image pull, 7B VLM weights into VRAM). While it loads:
+
+```bash
+git clone https://github.com/traversaal-ai/momentsearch.git && cd momentsearch
+cp .env.example .env
+# set these three lines, using the IP the script printed:
+#   LLM_PROVIDER=openai
+#   LLM_BASE_URL=http://<EXTERNAL-IP>/v1
+#   LLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct
+#   LLM_API_KEY=not-needed
+docker compose up --build -d
+python examples/quickstart.py          # seeds the sample corpus (four LLM talks)
+```
+
+Verify: open http://localhost:8000, ask "when does the speaker draw the attention
+diagram?" and confirm a cited answer returns in a few seconds.
+
+Stage three windows before class: browser on the app, a terminal running
+`kubectl get pods -w`, and a spare terminal for commands.
+
+## The five minutes, scripted
+
+| Clock | Do | Say |
+|---|---|---|
+| 0:00 | Ask the app a question; let the cited answer stream | "This answer was just written by a 7B open-source vision model reading video frames. Not an API. It runs on a cluster I own." |
+| 1:00 | Show the three `.env` lines | "Swapping OpenAI for my own fleet was these three lines. vLLM speaks the same protocol. That is the whole trick of owning your inference." |
+| 1:45 | Show `kubectl get pods`: two Ready replicas | "Two identical pods, one GPU each, behind one front door. The fleet shape from the session." |
+| 2:15 | `kubectl delete pod <one of them>`, immediately re-ask in the app | "I just killed half the fleet mid-question. The answer keeps streaming: the readiness gate holds traffic on the healthy replica while Kubernetes resurrects the dead one." |
+| 3:30 | `kubectl scale deployment vllm --replicas=3`; watch Pending in the pods window | "Three replicas wanted, two GPUs owned. Watch the cluster literally buy a machine. This takes minutes, which is exactly why real fleets keep a warm floor instead of chasing spikes." |
+| 4:30 | Leave the node provisioning on screen | "Everything you just watched is Assignment 3. You will build this exact stack and break it three ways on purpose." |
+
+The node typically reaches Ready after the talking is done; that is fine, the Pending
+state and the node appearing are the demo, not the completion.
+
+## Reset (between rehearsal and class)
+
+```bash
+kubectl scale deployment vllm --replicas=2
+```
+
+The autoscaler removes the extra Spot node after its scale-down delay; no other reset
+is needed. Re-ask one question to confirm health.
+
+## Teardown (same day, always)
+
+```bash
+./teardown.sh
+```
+
+Then check the billing page. GPUs bill while idle.
+
+## Troubleshooting
+
+- **Pods Pending forever:** GPU quota. `gcloud compute regions describe us-central1`
+  shows usage; the quota request page is the fix.
+- **EXTERNAL-IP stuck on `<pending>`:** wait 2 to 3 minutes; LoadBalancers are slow to
+  program. Firewall is handled by GKE automatically.
+- **CUDA out of memory:** drop to `Qwen/Qwen2.5-VL-3B-Instruct` in the manifest, or
+  lower `--max-model-len` to 4096.
+- **Slow first token on frame-heavy questions:** expected; six images per prompt is
+  real multimodal prefill. It is a talking point, not a bug.
+- **Spot preemption during the demo:** rare, and if it happens it IS the demo. Say
+  "that was a real preemption" and let the readiness gate carry the moment.

--- a/FDE/Assignment_3_AI_Infra_K8s/demo/provision.sh
+++ b/FDE/Assignment_3_AI_Infra_K8s/demo/provision.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Provision the demo stack: GKE cluster + Spot L4 pool + the vLLM fleet.
+# Idempotent enough to re-run; ~10 min to cluster, ~5-10 more to model Ready.
+set -euo pipefail
+
+ZONE="${ZONE:-us-central1-a}"
+CLUSTER="${CLUSTER:-fde-lab}"
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo ">> project: $(gcloud config get-value project 2>/dev/null)"
+
+if ! gcloud container clusters describe "$CLUSTER" --zone "$ZONE" >/dev/null 2>&1; then
+  echo ">> creating cluster $CLUSTER"
+  gcloud container clusters create "$CLUSTER" \
+    --zone "$ZONE" --num-nodes 1 --machine-type e2-standard-4
+  gcloud container node-pools create gpu-pool \
+    --cluster "$CLUSTER" --zone "$ZONE" \
+    --machine-type g2-standard-8 \
+    --accelerator type=nvidia-l4,count=1,gpu-driver-version=latest \
+    --num-nodes 2 --enable-autoscaling --min-nodes 1 --max-nodes 3 --spot
+else
+  echo ">> cluster $CLUSTER already exists, reusing"
+fi
+
+gcloud container clusters get-credentials "$CLUSTER" --zone "$ZONE"
+
+echo ">> applying the fleet"
+kubectl apply -f "$DIR/manifests/vllm.yaml"
+
+echo ">> waiting for rollout (weights into VRAM takes 5-10 min on first boot)"
+kubectl rollout status deployment/vllm --timeout=20m
+
+echo ">> waiting for the front door"
+for i in $(seq 1 60); do
+  IP="$(kubectl get svc vllm -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+  [ -n "$IP" ] && break
+  sleep 5
+done
+[ -n "${IP:-}" ] || { echo "!! LoadBalancer IP never arrived"; exit 1; }
+
+echo ""
+echo ">> fleet is up. Point Moment Search .env at it:"
+echo "   LLM_PROVIDER=openai"
+echo "   LLM_BASE_URL=http://$IP/v1"
+echo "   LLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct"
+echo "   LLM_API_KEY=not-needed"

--- a/FDE/Assignment_3_AI_Infra_K8s/demo/teardown.sh
+++ b/FDE/Assignment_3_AI_Infra_K8s/demo/teardown.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Delete the demo cluster. GPUs bill while idle; run this the same day.
+set -euo pipefail
+ZONE="${ZONE:-us-central1-a}"
+CLUSTER="${CLUSTER:-fde-lab}"
+gcloud container clusters delete "$CLUSTER" --zone "$ZONE" --quiet
+echo ">> deleted. Now check the billing page and screenshot it."

--- a/FDE/Assignment_3_AI_Infra_K8s/eval/eval.py
+++ b/FDE/Assignment_3_AI_Infra_K8s/eval/eval.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Automated checks for Assignment 3: AI Infra on Kubernetes.
+
+Run BEFORE teardown, against the live cluster:
+
+    python eval/eval.py [--namespace default] [--deployment vllm] [--service vllm]
+
+Writes eval/REPORT.md with a pass/fail table for the automated rubric criteria.
+Manual criteria (writeup, video, teardown proof) are graded from your submission.
+Requires: kubectl configured for the cluster, and curl.
+"""
+import argparse, json, pathlib, subprocess, sys
+
+def sh(cmd, timeout=30):
+    try:
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "", "timeout"
+
+def kjson(args, ns):
+    code, out, _ = sh(f"kubectl -n {ns} get {args} -o json")
+    if code != 0:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--namespace", default="default")
+    ap.add_argument("--deployment", default="vllm")
+    ap.add_argument("--service", default="vllm")
+    a = ap.parse_args()
+    ns, dep, svc = a.namespace, a.deployment, a.service
+    results = []
+
+    def add(cid, ok, evidence):
+        results.append((cid, bool(ok), evidence))
+        print(f"[{'PASS' if ok else 'FAIL'}] {cid}: {evidence}")
+
+    code, out, err = sh("kubectl cluster-info")
+    add("cluster_reachable", code == 0, out.splitlines()[0] if out else err)
+
+    nodes = kjson("nodes", ns) or {"items": []}
+    gpu_nodes = [n["metadata"]["name"] for n in nodes["items"]
+                 if "nvidia.com/gpu" in n.get("status", {}).get("capacity", {})]
+    add("gpu_nodes", gpu_nodes, f"GPU nodes: {gpu_nodes or 'none found'}")
+
+    d = kjson(f"deployment {dep}", ns)
+    if not d:
+        add("fleet_replicas", False, f"deployment {dep} not found in namespace {ns}")
+        add("readiness_probe", False, "no deployment")
+        add("gpu_request", False, "no deployment")
+        add("zero_drop_rollout", False, "no deployment")
+    else:
+        want = d["spec"].get("replicas", 0)
+        ready = d.get("status", {}).get("readyReplicas", 0)
+        add("fleet_replicas", want >= 2 and ready == want,
+            f"replicas wanted={want} ready={ready}")
+
+        c = d["spec"]["template"]["spec"]["containers"][0]
+        probe = c.get("readinessProbe", {})
+        http = probe.get("httpGet", {})
+        add("readiness_probe",
+            http.get("path") == "/health" and str(http.get("port")) == "8000",
+            f"readinessProbe={probe or 'missing'}")
+
+        gpu = c.get("resources", {}).get("limits", {}).get("nvidia.com/gpu")
+        add("gpu_request", str(gpu) == "1", f"nvidia.com/gpu limit={gpu}")
+
+        ru = d["spec"].get("strategy", {}).get("rollingUpdate", {})
+        add("zero_drop_rollout",
+            str(ru.get("maxUnavailable")) in ("0", "0%") and ru.get("maxSurge") not in (None, 0, "0"),
+            f"rollingUpdate={ru or 'missing'}")
+
+    s = kjson(f"service {svc}", ns)
+    ip = ""
+    if s:
+        ing = s.get("status", {}).get("loadBalancer", {}).get("ingress", [])
+        ip = (ing[0].get("ip") or ing[0].get("hostname")) if ing else ""
+    add("front_door", bool(ip), f"external endpoint: {ip or 'none'}")
+
+    if ip:
+        body = json.dumps({"model": "Qwen/Qwen3-1.7B",
+                           "messages": [{"role": "user", "content": "Say ready."}],
+                           "max_tokens": 8})
+        code, out, err = sh(
+            f"curl -s -m 60 http://{ip}/v1/chat/completions "
+            f"-H 'Content-Type: application/json' -d '{body}'", timeout=70)
+        ok = code == 0 and '"choices"' in out
+        add("tokens_flow", ok, (out[:120] + "...") if ok else (err or out[:120] or "no response"))
+    else:
+        add("tokens_flow", False, "no external endpoint to test")
+
+    rubric = json.loads((pathlib.Path(__file__).parent / "rubric.json").read_text())
+    pts = {c["id"]: c["points"] for c in rubric["automated"]}
+    earned = sum(pts.get(cid, 0) for cid, ok, _ in results if ok)
+    total = sum(pts.values())
+
+    lines = ["# Assignment 3 automated scorecard", "",
+             f"Automated score: **{earned} / {total}** "
+             "(manual criteria graded from writeup, video, and teardown proof)", "",
+             "| Check | Result | Evidence |", "|---|---|---|"]
+    for cid, ok, ev in results:
+        lines.append(f"| {cid} | {'PASS' if ok else 'FAIL'} | {ev.replace('|', '/')} |")
+    lines += ["", "Reminder: tear the cluster down after this run. GPUs bill while idle."]
+    report = pathlib.Path(__file__).parent / "REPORT.md"
+    report.write_text("\n".join(lines) + "\n")
+    print(f"\nAutomated: {earned}/{total}. Wrote {report}")
+    sys.exit(0 if earned == total else 1)
+
+if __name__ == "__main__":
+    main()

--- a/FDE/Assignment_3_AI_Infra_K8s/eval/eval.py
+++ b/FDE/Assignment_3_AI_Infra_K8s/eval/eval.py
@@ -83,7 +83,7 @@ def main():
     add("front_door", bool(ip), f"external endpoint: {ip or 'none'}")
 
     if ip:
-        body = json.dumps({"model": "Qwen/Qwen3-1.7B",
+        body = json.dumps({"model": "Qwen/Qwen2.5-VL-7B-Instruct",
                            "messages": [{"role": "user", "content": "Say ready."}],
                            "max_tokens": 8})
         code, out, err = sh(

--- a/FDE/Assignment_3_AI_Infra_K8s/eval/rubric.json
+++ b/FDE/Assignment_3_AI_Infra_K8s/eval/rubric.json
@@ -1,0 +1,22 @@
+{
+  "assignment": "Assignment 3: AI Infra on Kubernetes",
+  "total_points": 100,
+  "automated": [
+    {"id": "cluster_reachable", "points": 5,  "check": "kubectl can reach a cluster context"},
+    {"id": "gpu_nodes",         "points": 10, "check": "at least one node advertises nvidia.com/gpu capacity"},
+    {"id": "fleet_replicas",    "points": 15, "check": "Deployment vllm exists with spec.replicas >= 2 and all replicas Ready"},
+    {"id": "readiness_probe",   "points": 15, "check": "readiness probe is httpGet /health on port 8000, not TCP"},
+    {"id": "gpu_request",       "points": 10, "check": "container requests nvidia.com/gpu: 1"},
+    {"id": "zero_drop_rollout", "points": 10, "check": "strategy has maxUnavailable 0 and maxSurge >= 1"},
+    {"id": "front_door",        "points": 5,  "check": "Service vllm has an external LoadBalancer IP"},
+    {"id": "tokens_flow",       "points": 10, "check": "POST /v1/chat/completions on the external IP returns choices"}
+  ],
+  "manual": [
+    {"id": "experiments_writeup", "points": 10, "check": "one page with three measured timings (Ready gap, scale-up chain, rollout) and actual spend"},
+    {"id": "video_demo",          "points": 5,  "check": "60-90s recording: pods -w during scale-up plus a streamed completion"},
+    {"id": "teardown_proof",      "points": 5,  "check": "post-teardown billing screenshot; no idle cluster left running"}
+  ],
+  "stretch_bonus": [
+    {"id": "stretch_goal", "points": 10, "check": "one of: tensor parallel on 2 GPUs, Kueue queue with 1-GPU quota, or Inference Gateway routing, with evidence"}
+  ]
+}

--- a/FDE/Assignment_3_AI_Infra_K8s/eval/rubric.json
+++ b/FDE/Assignment_3_AI_Infra_K8s/eval/rubric.json
@@ -2,21 +2,74 @@
   "assignment": "Assignment 3: AI Infra on Kubernetes",
   "total_points": 100,
   "automated": [
-    {"id": "cluster_reachable", "points": 5,  "check": "kubectl can reach a cluster context"},
-    {"id": "gpu_nodes",         "points": 10, "check": "at least one node advertises nvidia.com/gpu capacity"},
-    {"id": "fleet_replicas",    "points": 15, "check": "Deployment vllm exists with spec.replicas >= 2 and all replicas Ready"},
-    {"id": "readiness_probe",   "points": 15, "check": "readiness probe is httpGet /health on port 8000, not TCP"},
-    {"id": "gpu_request",       "points": 10, "check": "container requests nvidia.com/gpu: 1"},
-    {"id": "zero_drop_rollout", "points": 10, "check": "strategy has maxUnavailable 0 and maxSurge >= 1"},
-    {"id": "front_door",        "points": 5,  "check": "Service vllm has an external LoadBalancer IP"},
-    {"id": "tokens_flow",       "points": 10, "check": "POST /v1/chat/completions on the external IP returns choices"}
+    {
+      "id": "cluster_reachable",
+      "points": 5,
+      "check": "kubectl can reach a cluster context"
+    },
+    {
+      "id": "gpu_nodes",
+      "points": 10,
+      "check": "at least one node advertises nvidia.com/gpu capacity"
+    },
+    {
+      "id": "fleet_replicas",
+      "points": 15,
+      "check": "Deployment vllm exists with spec.replicas >= 2 and all replicas Ready"
+    },
+    {
+      "id": "readiness_probe",
+      "points": 15,
+      "check": "readiness probe is httpGet /health on port 8000, not TCP"
+    },
+    {
+      "id": "gpu_request",
+      "points": 10,
+      "check": "container requests nvidia.com/gpu: 1"
+    },
+    {
+      "id": "zero_drop_rollout",
+      "points": 10,
+      "check": "strategy has maxUnavailable 0 and maxSurge >= 1"
+    },
+    {
+      "id": "front_door",
+      "points": 5,
+      "check": "Service vllm has an external LoadBalancer IP"
+    },
+    {
+      "id": "tokens_flow",
+      "points": 10,
+      "check": "POST /v1/chat/completions on the external IP returns choices"
+    }
   ],
   "manual": [
-    {"id": "experiments_writeup", "points": 10, "check": "one page with three measured timings (Ready gap, scale-up chain, rollout) and actual spend"},
-    {"id": "video_demo",          "points": 5,  "check": "60-90s recording: pods -w during scale-up plus a streamed completion"},
-    {"id": "teardown_proof",      "points": 5,  "check": "post-teardown billing screenshot; no idle cluster left running"}
+    {
+      "id": "app_end_to_end",
+      "points": 5,
+      "check": "Moment Search answers with citations through the student's fleet (screenshot or video)"
+    },
+    {
+      "id": "experiments_writeup",
+      "points": 5,
+      "check": "one page with three measured timings (Ready gap, scale-up chain, rollout), Rung A vs B notes, and actual spend"
+    },
+    {
+      "id": "video_demo",
+      "points": 5,
+      "check": "60-90s recording: the app answering via the fleet, then pods -w during scale-up"
+    },
+    {
+      "id": "teardown_proof",
+      "points": 5,
+      "check": "post-teardown billing screenshot; no idle cluster left running"
+    }
   ],
   "stretch_bonus": [
-    {"id": "stretch_goal", "points": 10, "check": "one of: tensor parallel on 2 GPUs, Kueue queue with 1-GPU quota, or Inference Gateway routing, with evidence"}
+    {
+      "id": "stretch_goal",
+      "points": 10,
+      "check": "one of: tensor parallel on 2 GPUs, Kueue queue with 1-GPU quota, or Inference Gateway routing, with evidence"
+    }
   ]
 }

--- a/FDE/Assignment_3_AI_Infra_K8s/manifests/vllm.yaml
+++ b/FDE/Assignment_3_AI_Infra_K8s/manifests/vllm.yaml
@@ -1,0 +1,59 @@
+# Provided scaffolding: the inference fleet.
+# Read every field before applying. Each one exists for a reason covered in the session.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+  labels:
+    app: vllm
+spec:
+  replicas: 2                       # the fleet: N identical copies, one per GPU
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0             # never dip below full capacity during a roll
+      maxSurge: 1                   # bring the new pod up before killing the old
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      terminationGracePeriodSeconds: 120   # let in-flight streams finish
+      tolerations:
+      - key: nvidia.com/gpu               # the velvet rope: only GPU workloads pass
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: vllm
+        image: vllm/vllm-openai:latest
+        args:
+        - "--model"
+        - "Qwen/Qwen3-1.7B"
+        - "--max-model-len"
+        - "4096"
+        ports:
+        - containerPort: 8000
+        resources:
+          limits:
+            nvidia.com/gpu: 1             # whole units, no fractions by default
+        readinessProbe:
+          httpGet:
+            path: /health                 # model in memory, never just "port open"
+            port: 8000
+          initialDelaySeconds: 60         # weights take minutes, not seconds
+          periodSeconds: 10
+          failureThreshold: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm
+spec:
+  type: LoadBalancer                      # the front door
+  selector:
+    app: vllm
+  ports:
+  - port: 80
+    targetPort: 8000

--- a/FDE/Assignment_3_AI_Infra_K8s/manifests/vllm.yaml
+++ b/FDE/Assignment_3_AI_Infra_K8s/manifests/vllm.yaml
@@ -1,5 +1,6 @@
-# Provided scaffolding: the inference fleet.
+# Provided scaffolding: the inference fleet behind Moment Search.
 # Read every field before applying. Each one exists for a reason covered in the session.
+# The model is VISION-capable on purpose: Moment Search shows it actual video frames.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,9 +31,11 @@ spec:
         image: vllm/vllm-openai:latest
         args:
         - "--model"
-        - "Qwen/Qwen3-1.7B"
+        - "Qwen/Qwen2.5-VL-7B-Instruct"   # vision model: it must read frames
         - "--max-model-len"
-        - "4096"
+        - "8192"
+        - "--limit-mm-per-prompt"
+        - "image=8"                       # Moment Search sends TOP_K=6 frames
         ports:
         - containerPort: 8000
         resources:
@@ -42,16 +45,16 @@ spec:
           httpGet:
             path: /health                 # model in memory, never just "port open"
             port: 8000
-          initialDelaySeconds: 60         # weights take minutes, not seconds
+          initialDelaySeconds: 90         # a 7B VLM takes minutes to load, not seconds
           periodSeconds: 10
-          failureThreshold: 30
+          failureThreshold: 40
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: vllm
 spec:
-  type: LoadBalancer                      # the front door
+  type: LoadBalancer                      # the front door Moment Search points at
   selector:
     app: vllm
   ports:

--- a/FDE/README.md
+++ b/FDE/README.md
@@ -64,6 +64,7 @@ Four classes, four real-world products, all built end to end — from efficiency
 | # | Name | You build | Core skills |
 |---|------|-----------|-------------|
 | 1 | [Live Translate](Assignment_1_Live_Translate/) | A two-service backend (Node gateway + Python AI service) behind a provided browser widget that live-translates any page EN → Mexican Spanish | LLM calls, caching, structured logging + tracing, service separation, API contracts, deploy on Fly.io |
+| 3 | [AI Infra on Kubernetes](Assignment_3_AI_Infra_K8s/) | A real GKE cluster serving vLLM as a two-replica fleet behind a LoadBalancer, plus three break-and-fix production experiments and a graded teardown | Kubernetes (pods, node pools, probes, rollouts), GPU scheduling, vLLM serving, capacity and cost hygiene |
 | … | _more coming_ | | |
 
 Each assignment folder is self-contained with its own `README.md`, provided scaffolding,

--- a/FDE/README.md
+++ b/FDE/README.md
@@ -64,7 +64,7 @@ Four classes, four real-world products, all built end to end — from efficiency
 | # | Name | You build | Core skills |
 |---|------|-----------|-------------|
 | 1 | [Live Translate](Assignment_1_Live_Translate/) | A two-service backend (Node gateway + Python AI service) behind a provided browser widget that live-translates any page EN → Mexican Spanish | LLM calls, caching, structured logging + tracing, service separation, API contracts, deploy on Fly.io |
-| 3 | [AI Infra on Kubernetes](Assignment_3_AI_Infra_K8s/) | A real GKE cluster serving vLLM as a two-replica fleet behind a LoadBalancer, plus three break-and-fix production experiments and a graded teardown | Kubernetes (pods, node pools, probes, rollouts), GPU scheduling, vLLM serving, capacity and cost hygiene |
+| 3 | [AI Infra on Kubernetes](Assignment_3_AI_Infra_K8s/) | Moment Search rewired onto your own open-source vision LLM: first one box on RunPod, then a two-replica vLLM fleet on GKE behind a LoadBalancer, with three break-and-fix production experiments and a graded teardown | Kubernetes (pods, node pools, probes, rollouts), GPU scheduling, vLLM serving, OpenAI-compatible model swaps, capacity and cost hygiene |
 | … | _more coming_ | | |
 
 Each assignment folder is self-contained with its own `README.md`, provided scaffolding,


### PR DESCRIPTION
## What this adds

Materials for the July 23 guest session (**AI training, tuning, inference and RL on Kubernetes**, Sanjeev Ganjihal) plus its companion assignment, built to the FDE track's conventions and scaffolded on Moment Search per our discussion.

**`FDE/Assignment_3_AI_Infra_K8s/`**

- **README.md**: the assignment. Students extend Moment Search toward RAG at scale by replacing the hosted LLM with an open-source vision model they serve themselves, in two rungs. Rung A: their first time serving, one box on RunPod with vLLM (framing updated per your note that students have only consumed models through OpenAI-style APIs so far). Rung B, graded: the same model as a two-replica vLLM fleet on GKE behind a LoadBalancer, the app rewired via its three `LLM_BASE_URL` env lines, then three break-and-fix experiments observed through the running app: the lying readiness probe, timing the capacity chain when scale-up buys a node, and a zero-drop rollout under a streaming answer. Quota request framed as real FDE work; teardown graded; ~$5 inside the GCP free credit; kind-cluster fallback if quota stalls.
- **demo/**: the live-demo runbook for the session, five minutes scripted minute by minute (Moment Search answering with citations from the fleet, a pod killed mid-question while the answer keeps streaming, a live Spot GPU node purchase on scale-out), with `provision.sh` / `teardown.sh` so an engineer can reproduce everything end to end in ~45 minutes and ~$3 before class.
- **SESSION_NOTES.md**: the session recap students keep (four workload shapes and their K8s patterns, the 5-layer AI infra stack, the parallelism toolbox, the field guide, July 2026 receipts with sources).
- **AGENTS.md** non-negotiables, **manifests/vllm.yaml** (every field commented), **eval/** rubric + automated scorecard script run against the live cluster before teardown.

Also adds the Assignment 3 row to the FDE track table.

## Two implementation notes worth knowing

- Moment Search shows the LLM actual video frames, so the served model must be **vision-capable**: the manifests use `Qwen/Qwen2.5-VL-7B-Instruct` with `--limit-mm-per-prompt image=8`. A text-only model fails at the first question.
- The GPU node pool is created with `--enable-autoscaling --max-nodes 3`; without it, the "watch the cluster buy a node" experiment hangs in Pending forever.

Happy to iterate on any of it so the demo and assignment fit the rest of the course.